### PR TITLE
VCST-2612: Add validation for inactive payment methods

### DIFF
--- a/src/VirtoCommerce.XOrder.Core/Validators/OrderErrorDescriber.cs
+++ b/src/VirtoCommerce.XOrder.Core/Validators/OrderErrorDescriber.cs
@@ -38,5 +38,10 @@ namespace VirtoCommerce.XOrder.Core.Validators
         {
             return $"The payment method code:{code} unavailable";
         }
+
+        public static string PaymentMethodInactive(string gatewayCode)
+        {
+            return $"Payment method {gatewayCode} is inactive";
+        }
     }
 }

--- a/src/VirtoCommerce.XOrder.Core/Validators/PaymentRequestValidator.cs
+++ b/src/VirtoCommerce.XOrder.Core/Validators/PaymentRequestValidator.cs
@@ -25,6 +25,11 @@ namespace VirtoCommerce.XOrder.Core.Validators
                 .WithMessage(x => OrderErrorDescriber.PaymentMethodNotFound(x.Payment.GatewayCode))
                 .When(x => x.Payment != null);
 
+            RuleFor(x => x.Payment.PaymentMethod.IsActive)
+                .Equal(true)
+                .WithMessage(x => OrderErrorDescriber.PaymentMethodInactive(x.Payment.GatewayCode))
+                .When(x => x.Payment?.PaymentMethod != null);
+
             RuleFor(x => x.Store)
                 .NotNull()
                 .WithMessage(OrderErrorDescriber.StoreNotFound());


### PR DESCRIPTION
## Description
fix: Added a new method `PaymentMethodInactive` to the `OrderErrorDescriber` class to return a message indicating an inactive payment method. Updated the `PaymentRequestValidator` class to include a rule that checks if the `PaymentMethod.IsActive` property is `true`, using the new method to provide an error message if the payment method is inactive.

## References
### QA-test:
### Jira-link:


https://virtocommerce.atlassian.net/browse/VCST-2621
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XOrder_3.902.0-pr-19-eaf8.zip