### PR TITLE
VCST-3017: Add Store support to CustomerOrderAggregate and related types

### DIFF
--- a/src/VirtoCommerce.XOrder.Core/CustomerOrderAggregate.cs
+++ b/src/VirtoCommerce.XOrder.Core/CustomerOrderAggregate.cs
@@ -12,6 +12,7 @@ using VirtoCommerce.PaymentModule.Core.Model;
 using VirtoCommerce.PaymentModule.Model.Requests;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Domain;
+using VirtoCommerce.StoreModule.Core.Model;
 using VirtoCommerce.Xapi.Core.Models;
 using VirtoCommerce.Xapi.Core.Services;
 using VirtoCommerce.XOrder.Core.Validators;
@@ -33,10 +34,13 @@ namespace VirtoCommerce.XOrder.Core
         public CustomerOrder Order { get; protected set; }
         public Currency Currency { get; protected set; }
 
-        public CustomerOrderAggregate GrabCustomerOrder(CustomerOrder order, Currency currency)
+        public Store Store { get; protected set; }
+
+        public CustomerOrderAggregate GrabCustomerOrder(CustomerOrder order, Currency currency, Store store)
         {
             Order = order;
             Currency = currency;
+            Store = store;
 
             return this;
         }

--- a/src/VirtoCommerce.XOrder.Core/Schemas/CustomerOrderType.cs
+++ b/src/VirtoCommerce.XOrder.Core/Schemas/CustomerOrderType.cs
@@ -9,7 +9,6 @@ using VirtoCommerce.PaymentModule.Core.Services;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Settings;
 using VirtoCommerce.Xapi.Core.Extensions;
-using VirtoCommerce.Xapi.Core.Helpers;
 using VirtoCommerce.Xapi.Core.Schemas;
 using VirtoCommerce.Xapi.Core.Services;
 using OrderSettings = VirtoCommerce.OrdersModule.Core.ModuleConstants.Settings.General;
@@ -154,7 +153,7 @@ namespace VirtoCommerce.XOrder.Core.Schemas
             ExtendableFieldAsync<NonNullGraphType<ListGraphType<NonNullGraphType<DynamicPropertyValueType>>>>(
                 "dynamicProperties",
                 "Customer order dynamic property values",
-                QueryArgumentPresets.GetArgumentForDynamicProperties(),
+                null,
                 async context => await dynamicPropertyResolverService.LoadDynamicPropertyValues(context.Source.Order, context.GetCultureName()));
 
             ExtendableField<NonNullGraphType<ListGraphType<NonNullGraphType<StringGraphType>>>>("coupons", resolve: x => x.Source.GetCustomerOrderCoupons());

--- a/src/VirtoCommerce.XOrder.Core/Schemas/OrderShipmentType.cs
+++ b/src/VirtoCommerce.XOrder.Core/Schemas/OrderShipmentType.cs
@@ -105,7 +105,7 @@ namespace VirtoCommerce.XOrder.Core.Schemas
             ExtendableFieldAsync<NonNullGraphType<ListGraphType<NonNullGraphType<DynamicPropertyValueType>>>>(
                 "dynamicProperties",
                 "Customer order Shipment dynamic property values",
-                QueryArgumentPresets.GetArgumentForDynamicProperties(),
+                null,
                 async context => await dynamicPropertyResolverService.LoadDynamicPropertyValues(context.Source, context.GetCultureName()));
         }
     }

--- a/src/VirtoCommerce.XOrder.Core/Schemas/PaymentInType.cs
+++ b/src/VirtoCommerce.XOrder.Core/Schemas/PaymentInType.cs
@@ -97,7 +97,7 @@ namespace VirtoCommerce.XOrder.Core.Schemas
             ExtendableFieldAsync<NonNullGraphType<ListGraphType<NonNullGraphType<DynamicPropertyValueType>>>>(
                 "dynamicProperties",
                 "Customer order Payment dynamic property values",
-                QueryArgumentPresets.GetArgumentForDynamicProperties(),
+                null,
                 async context => await dynamicPropertyResolverService.LoadDynamicPropertyValues(context.Source, context.GetCultureName()));
         }
     }

--- a/tests/VirtoCommerce.XOrder.Tests/Helpers/CustomerOrderMockHelper.cs
+++ b/tests/VirtoCommerce.XOrder.Tests/Helpers/CustomerOrderMockHelper.cs
@@ -113,7 +113,7 @@ namespace VirtoCommerce.XOrder.Tests.Helpers
                 _dynamicPropertyUpdaterService.Object,
                 _promotionUsageSearchService.Object);
 
-            aggregate.GrabCustomerOrder(customerOrder, currency);
+            aggregate.GrabCustomerOrder(customerOrder, currency, null);
 
             return aggregate;
         }


### PR DESCRIPTION
## Description
feat: Introduced a Store property in CustomerOrderAggregate
fix: Modified CustomerOrderType, OrderLineItemType, OrderShipmentType, PaymentType to change dynamic properties handling by removing the query argument preset.

## References
### QA-test:
### Jira-link:

https://virtocommerce.atlassian.net/browse/VCST-3017
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XOrder_3.910.0-pr-28-ab4c.zip