### PR TITLE
VCST-3449: PickupLocationId for order query

### DIFF
--- a/src/VirtoCommerce.XOrder.Core/Extensions/ResolveFieldContextExtensions.cs
+++ b/src/VirtoCommerce.XOrder.Core/Extensions/ResolveFieldContextExtensions.cs
@@ -21,10 +21,10 @@ namespace VirtoCommerce.XOrder.Core.Extensions
             //Try to get a currency from order if currency code is not set explicitly or undefined
             var result = userContext.GetOrderCurrency();
             //If the passed currency differs from the order currency, we try to find it from the all registered currencies.
-            if (result == null || !string.IsNullOrEmpty(currencyCode) && !result.Code.EqualsInvariant(currencyCode))
+            if (result == null || !string.IsNullOrEmpty(currencyCode) && !result.Code.EqualsIgnoreCase(currencyCode))
             {
                 var allCurrencies = userContext.GetValue<IEnumerable<Currency>>("allCurrencies");
-                result = allCurrencies?.FirstOrDefault(x => x.Code.EqualsInvariant(currencyCode));
+                result = allCurrencies?.FirstOrDefault(x => x.Code.EqualsIgnoreCase(currencyCode));
             }
             if (result == null)
             {

--- a/src/VirtoCommerce.XOrder.Core/Validators/OrderPaymentValidator.cs
+++ b/src/VirtoCommerce.XOrder.Core/Validators/OrderPaymentValidator.cs
@@ -15,7 +15,7 @@ namespace VirtoCommerce.XOrder.Core.Validators
 
                 if (availPaymentMethods != null && !string.IsNullOrEmpty(paymentCode))
                 {
-                    var paymentMethod = availPaymentMethods.FirstOrDefault(x => paymentCode.EqualsInvariant(x.Code));
+                    var paymentMethod = availPaymentMethods.FirstOrDefault(x => paymentCode.EqualsIgnoreCase(x.Code));
                     if (paymentMethod == null)
                     {
                         context.AddFailure(OrderErrorDescriber.PaymentMethodUnavailable(paymentCode));

--- a/src/VirtoCommerce.XOrder.Core/VirtoCommerce.XOrder.Core.csproj
+++ b/src/VirtoCommerce.XOrder.Core/VirtoCommerce.XOrder.Core.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.853.0-alpha.1344-vcst-3449" />
+    <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.853.0-alpha.1348-vcst-3449" />
     <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.915.0" />
-    <PackageReference Include="VirtoCommerce.XCart.Core" Version="3.923.0-alpha.120-vcst-3449" />
+    <PackageReference Include="VirtoCommerce.XCart.Core" Version="3.926.0-alpha.134-vcst-3449" />
     <PackageReference Include="VirtoCommerce.XCatalog.Core" Version="3.919.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.XOrder.Core/VirtoCommerce.XOrder.Core.csproj
+++ b/src/VirtoCommerce.XOrder.Core/VirtoCommerce.XOrder.Core.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.845.0" />
-    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.906.0" />
-    <PackageReference Include="VirtoCommerce.XCart.Core" Version="3.906.0" />
-    <PackageReference Include="VirtoCommerce.XCatalog.Core" Version="3.916.0" />
+    <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.853.0-alpha.1343-vcst-3449" />
+    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.915.0" />
+    <PackageReference Include="VirtoCommerce.XCart.Core" Version="3.923.0-alpha.118-vcst-3449" />
+    <PackageReference Include="VirtoCommerce.XCatalog.Core" Version="3.919.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.XOrder.Core/VirtoCommerce.XOrder.Core.csproj
+++ b/src/VirtoCommerce.XOrder.Core/VirtoCommerce.XOrder.Core.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.853.0-alpha.1348-vcst-3449" />
+    <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.853.0" />
     <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.809.0" />
     <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.915.0" />
-    <PackageReference Include="VirtoCommerce.XCart.Core" Version="3.926.0-alpha.134-vcst-3449" />
+    <PackageReference Include="VirtoCommerce.XCart.Core" Version="3.926.0" />
     <PackageReference Include="VirtoCommerce.XCatalog.Core" Version="3.919.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.XOrder.Core/VirtoCommerce.XOrder.Core.csproj
+++ b/src/VirtoCommerce.XOrder.Core/VirtoCommerce.XOrder.Core.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.853.0-alpha.1343-vcst-3449" />
+    <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.853.0-alpha.1344-vcst-3449" />
     <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.915.0" />
-    <PackageReference Include="VirtoCommerce.XCart.Core" Version="3.923.0-alpha.118-vcst-3449" />
+    <PackageReference Include="VirtoCommerce.XCart.Core" Version="3.923.0-alpha.120-vcst-3449" />
     <PackageReference Include="VirtoCommerce.XCatalog.Core" Version="3.919.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.XOrder.Data/Middlewares/ShipmentContextMiddleware.cs
+++ b/src/VirtoCommerce.XOrder.Data/Middlewares/ShipmentContextMiddleware.cs
@@ -35,7 +35,7 @@ namespace VirtoCommerce.XOrder.Data.Middlewares
             var shipment = parameter.Shipment;
             var shippingAddressPolicy = GetShippingPolicy(parameter);
 
-            if (shipment?.DeliveryAddress != null || !shippingAddressPolicy.EqualsInvariant(XOrderSetting.ShippingAddressPolicyPreviousOrder))
+            if (shipment?.DeliveryAddress != null || !shippingAddressPolicy.EqualsIgnoreCase(XOrderSetting.ShippingAddressPolicyPreviousOrder))
             {
                 return;
             }

--- a/src/VirtoCommerce.XOrder.Data/VirtoCommerce.XOrder.Data.csproj
+++ b/src/VirtoCommerce.XOrder.Data/VirtoCommerce.XOrder.Data.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="VirtoCommerce.FileExperienceApi.Core" Version="3.904.0" />
     <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.877.0" />
-    <PackageReference Include="VirtoCommerce.XCatalog.Data" Version="3.916.0" />
+    <PackageReference Include="VirtoCommerce.XCatalog.Data" Version="3.919.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.XOrder.Core\VirtoCommerce.XOrder.Core.csproj" />

--- a/src/VirtoCommerce.XOrder.Web/module.manifest
+++ b/src/VirtoCommerce.XOrder.Web/module.manifest
@@ -8,9 +8,9 @@
   <dependencies>
     <dependency id="VirtoCommerce.FileExperienceApi" version="3.904.0" />
     <dependency id="VirtoCommerce.Orders" version="3.853.0-alpha.1344-vcst-3449" />
-    <dependency id="VirtoCommerce.Xapi" version="3.906.0" />
+    <dependency id="VirtoCommerce.Xapi" version="3.915.0" />
     <dependency id="VirtoCommerce.XCart" version="3.923.0-alpha.120-vcst-3449" />
-    <dependency id="VirtoCommerce.XCatalog" version="3.916.0" />
+    <dependency id="VirtoCommerce.XCatalog" version="3.919.0" />
   </dependencies>
 
   <title>Order Experience API</title>

--- a/src/VirtoCommerce.XOrder.Web/module.manifest
+++ b/src/VirtoCommerce.XOrder.Web/module.manifest
@@ -7,9 +7,9 @@
   <platformVersion>3.877.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.FileExperienceApi" version="3.904.0" />
-    <dependency id="VirtoCommerce.Orders" version="3.853.0-alpha.1344-vcst-3449" />
+    <dependency id="VirtoCommerce.Orders" version="3.853.0-alpha.1348-vcst-3449" />
     <dependency id="VirtoCommerce.Xapi" version="3.915.0" />
-    <dependency id="VirtoCommerce.XCart" version="3.923.0-alpha.120-vcst-3449" />
+    <dependency id="VirtoCommerce.XCart" version="3.926.0-alpha.134-vcst-3449" />
     <dependency id="VirtoCommerce.XCatalog" version="3.919.0" />
   </dependencies>
 

--- a/src/VirtoCommerce.XOrder.Web/module.manifest
+++ b/src/VirtoCommerce.XOrder.Web/module.manifest
@@ -7,9 +7,9 @@
   <platformVersion>3.877.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.FileExperienceApi" version="3.904.0" />
-    <dependency id="VirtoCommerce.Orders" version="3.845.0" />
+    <dependency id="VirtoCommerce.Orders" version="3.853.0-alpha.1344-vcst-3449" />
     <dependency id="VirtoCommerce.Xapi" version="3.906.0" />
-    <dependency id="VirtoCommerce.XCart" version="3.906.0" />
+    <dependency id="VirtoCommerce.XCart" version="3.923.0-alpha.120-vcst-3449" />
     <dependency id="VirtoCommerce.XCatalog" version="3.916.0" />
   </dependencies>
 

--- a/src/VirtoCommerce.XOrder.Web/module.manifest
+++ b/src/VirtoCommerce.XOrder.Web/module.manifest
@@ -7,10 +7,10 @@
   <platformVersion>3.877.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.FileExperienceApi" version="3.904.0" />
-    <dependency id="VirtoCommerce.Orders" version="3.853.0-alpha.1348-vcst-3449" />
+    <dependency id="VirtoCommerce.Orders" version="3.853.0" />
     <dependency id="VirtoCommerce.Payment" version="3.809.0" />
     <dependency id="VirtoCommerce.Xapi" version="3.915.0" />
-    <dependency id="VirtoCommerce.XCart" version="3.926.0-alpha.134-vcst-3449" />
+    <dependency id="VirtoCommerce.XCart" version="3.926.0" />
     <dependency id="VirtoCommerce.XCatalog" version="3.919.0" />
   </dependencies>
 

--- a/tests/VirtoCommerce.XOrder.Tests/Handlers/CreateOrderFromCartCommandHandlerTests.cs
+++ b/tests/VirtoCommerce.XOrder.Tests/Handlers/CreateOrderFromCartCommandHandlerTests.cs
@@ -13,7 +13,9 @@ using VirtoCommerce.CartModule.Core.Services;
 using VirtoCommerce.CoreModule.Core.Currency;
 using VirtoCommerce.CustomerModule.Core.Model;
 using VirtoCommerce.CustomerModule.Core.Services;
+using VirtoCommerce.FileExperienceApi.Core.Services;
 using VirtoCommerce.MarketingModule.Core.Services;
+using VirtoCommerce.Platform.Core.Modularity;
 using VirtoCommerce.TaxModule.Core.Services;
 using VirtoCommerce.Xapi.Core.Pipelines;
 using VirtoCommerce.Xapi.Core.Services;
@@ -113,7 +115,7 @@ namespace VirtoCommerce.XOrder.Tests.Handlers
             customerAggrRep.Setup(x => x.CreateOrderFromCart(It.IsAny<ShoppingCart>()))
                 .ReturnsAsync(new CustomerOrderAggregate(null, null));
 
-            var cartAggregate = new CartAggregate(null, null, null, null, null, null, null, null);
+            var cartAggregate = new CartAggregate(null, null, null, null, null, null, null, null, null, null);
             cartAggregate.GrabCart(cart, new Store(), new Contact(), new Currency());
 
             var cartAggrRepository = new Mock<ICartAggregateRepository>();
@@ -154,12 +156,14 @@ namespace VirtoCommerce.XOrder.Tests.Handlers
             var cartAggregate = new CartAggregate(
                 Mock.Of<IMarketingPromoEvaluator>(),
                 Mock.Of<IShoppingCartTotalsCalculator>(),
-                new Mock<ITaxProviderSearchService>().Object,
+                new Mock<IOptionalDependency<ITaxProviderSearchService>>().Object,
                 Mock.Of<ICartProductService>(),
                 Mock.Of<IDynamicPropertyUpdaterService>(),
                 Mock.Of<IMapper>(),
                 Mock.Of<IMemberService>(),
-                Mock.Of<IGenericPipelineLauncher>());
+                Mock.Of<IGenericPipelineLauncher>(),
+                Mock.Of<IConfigurationItemValidator>(),
+                Mock.Of<IFileUploadService>());
 
             var contact = new Contact()
             {


### PR DESCRIPTION
## Description

* Save PickupLocationid for CreateOrderFromCart mutation
* Return PickupLocation for Order query

### Changes for `GetFullOrder` query

```graphql
fragment fullOrderFields on CustomerOrderType {
  shipments {
    pickupLocation {
      id,name,description,geoLocation,deliveryDays,storageDays,contactEmail,contactPhone,workingHours,isActive
      address {
        id,key,name,organization,countryCode,countryName,city,postalCode,line1,line2,regionId,regionName,phone,email,outerId,description,addressType
      }
    }
    ...
  }
  ...
}
```

## References
### QA-test:
### Jira-link:








https://virtocommerce.atlassian.net/browse/VCST-3449
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XOrder_3.913.0-pr-29-2fc4.zip