### PR TITLE
VCST-3755: Update VirtoCommerce.Orders version to 3.854.0

### DIFF
--- a/src/VirtoCommerce.XOrder.Core/VirtoCommerce.XOrder.Core.csproj
+++ b/src/VirtoCommerce.XOrder.Core/VirtoCommerce.XOrder.Core.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.853.0" />
+    <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.854.0" />
     <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.809.0" />
     <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.915.0" />
     <PackageReference Include="VirtoCommerce.XCart.Core" Version="3.926.0" />

--- a/src/VirtoCommerce.XOrder.Web/module.manifest
+++ b/src/VirtoCommerce.XOrder.Web/module.manifest
@@ -7,7 +7,7 @@
   <platformVersion>3.877.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.FileExperienceApi" version="3.904.0" />
-    <dependency id="VirtoCommerce.Orders" version="3.853.0" />
+    <dependency id="VirtoCommerce.Orders" version="3.854.0" />
     <dependency id="VirtoCommerce.Payment" version="3.809.0" />
     <dependency id="VirtoCommerce.Xapi" version="3.915.0" />
     <dependency id="VirtoCommerce.XCart" version="3.926.0" />


### PR DESCRIPTION
## Description
fix: Update VirtoCommerce.Orders version to 3.854.0

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-3755
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XOrder_3.914.0-pr-32-9018.zip