### PR TITLE
VCST-4564: Refactor payment processing to use async methods

### DIFF
--- a/src/VirtoCommerce.XOrder.Core/CustomerOrderAggregate.cs
+++ b/src/VirtoCommerce.XOrder.Core/CustomerOrderAggregate.cs
@@ -56,7 +56,7 @@ namespace VirtoCommerce.XOrder.Core
             return ProcessOrderPayment(request, default);
         }
 
-        public async Task<ProcessPaymentRequestResult> ProcessOrderPayment(ProcessPaymentRequest request, CancellationToken cancellationToken = default)
+        public async Task<ProcessPaymentRequestResult> ProcessOrderPayment(ProcessPaymentRequest request, CancellationToken cancellationToken)
         {
             var result = new ProcessPaymentRequestResult();
 

--- a/src/VirtoCommerce.XOrder.Core/CustomerOrderAggregate.cs
+++ b/src/VirtoCommerce.XOrder.Core/CustomerOrderAggregate.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentValidation;
 using VirtoCommerce.CoreModule.Core.Currency;
@@ -50,7 +51,12 @@ namespace VirtoCommerce.XOrder.Core
             Order.Status = status;
         }
 
-        public async Task<ProcessPaymentRequestResult> ProcessOrderPayment(ProcessPaymentRequest request)
+        public Task<ProcessPaymentRequestResult> ProcessOrderPayment(ProcessPaymentRequest request)
+        {
+            return ProcessOrderPayment(request, default);
+        }
+
+        public async Task<ProcessPaymentRequestResult> ProcessOrderPayment(ProcessPaymentRequest request, CancellationToken cancellationToken = default)
         {
             var result = new ProcessPaymentRequestResult();
 
@@ -77,7 +83,7 @@ namespace VirtoCommerce.XOrder.Core
             {
                 //This is definitely bad that we execute external business logic here, it must be done via domain events or in the event handler
                 //inside this aggregate we should do only related to order entities changes and should avoid of execution of external logic
-                result = await inPayment.PaymentMethod.ProcessPaymentAsync(request);
+                result = await inPayment.PaymentMethod.ProcessPaymentAsync(request, cancellationToken);
                 if (result.OuterId != null)
                 {
                     inPayment.OuterId = result.OuterId;

--- a/src/VirtoCommerce.XOrder.Core/CustomerOrderAggregate.cs
+++ b/src/VirtoCommerce.XOrder.Core/CustomerOrderAggregate.cs
@@ -50,7 +50,7 @@ namespace VirtoCommerce.XOrder.Core
             Order.Status = status;
         }
 
-        public ProcessPaymentRequestResult ProcessOrderPayment(ProcessPaymentRequest request)
+        public async Task<ProcessPaymentRequestResult> ProcessOrderPayment(ProcessPaymentRequest request)
         {
             var result = new ProcessPaymentRequestResult();
 
@@ -77,7 +77,7 @@ namespace VirtoCommerce.XOrder.Core
             {
                 //This is definitely bad that we execute external business logic here, it must be done via domain events or in the event handler
                 //inside this aggregate we should do only related to order entities changes and should avoid of execution of external logic
-                result = inPayment.PaymentMethod.ProcessPayment(request);
+                result = await inPayment.PaymentMethod.ProcessPaymentAsync(request);
                 if (result.OuterId != null)
                 {
                     inPayment.OuterId = result.OuterId;

--- a/src/VirtoCommerce.XOrder.Core/VirtoCommerce.XOrder.Core.csproj
+++ b/src/VirtoCommerce.XOrder.Core/VirtoCommerce.XOrder.Core.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.863.0" />
-    <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.813.0-alpha.266-vcst-4564" />
+    <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.813.0" />
     <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.929.0" />
     <PackageReference Include="VirtoCommerce.XCart.Core" Version="3.950.0" />
     <PackageReference Include="VirtoCommerce.XCatalog.Core" Version="3.942.0" />

--- a/src/VirtoCommerce.XOrder.Core/VirtoCommerce.XOrder.Core.csproj
+++ b/src/VirtoCommerce.XOrder.Core/VirtoCommerce.XOrder.Core.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.863.0" />
-    <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.811.0" />
+    <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.813.0-alpha.264-vcst-4564" />
     <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.929.0" />
     <PackageReference Include="VirtoCommerce.XCart.Core" Version="3.950.0" />
     <PackageReference Include="VirtoCommerce.XCatalog.Core" Version="3.942.0" />

--- a/src/VirtoCommerce.XOrder.Core/VirtoCommerce.XOrder.Core.csproj
+++ b/src/VirtoCommerce.XOrder.Core/VirtoCommerce.XOrder.Core.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.863.0" />
-    <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.813.0-alpha.264-vcst-4564" />
+    <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.813.0-alpha.266-vcst-4564" />
     <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.929.0" />
     <PackageReference Include="VirtoCommerce.XCart.Core" Version="3.950.0" />
     <PackageReference Include="VirtoCommerce.XCatalog.Core" Version="3.942.0" />

--- a/src/VirtoCommerce.XOrder.Data/Commands/AuthorizePaymentCommandHandler.cs
+++ b/src/VirtoCommerce.XOrder.Data/Commands/AuthorizePaymentCommandHandler.cs
@@ -37,7 +37,7 @@ namespace VirtoCommerce.XOrder.Data.Commands
 
             var parameters = GetParameters(request);
 
-            var validatePostProcessResult = paymentInfo.Payment.PaymentMethod.ValidatePostProcessRequest(parameters);
+            var validatePostProcessResult = await paymentInfo.Payment.PaymentMethod.ValidatePostProcessRequestAsync(parameters);
             if (!validatePostProcessResult.IsSuccess)
             {
                 return ErrorResult<AuthorizePaymentResult>(validatePostProcessResult.ErrorMessage);
@@ -54,7 +54,7 @@ namespace VirtoCommerce.XOrder.Data.Commands
                 Parameters = parameters,
             };
 
-            var processPaymentRequestResult = paymentInfo.Payment.PaymentMethod.PostProcessPayment(postProcessPaymentRequest);
+            var processPaymentRequestResult = await paymentInfo.Payment.PaymentMethod.PostProcessPaymentAsync(postProcessPaymentRequest);
 
             if (processPaymentRequestResult.IsSuccess)
             {

--- a/src/VirtoCommerce.XOrder.Data/Commands/AuthorizePaymentCommandHandler.cs
+++ b/src/VirtoCommerce.XOrder.Data/Commands/AuthorizePaymentCommandHandler.cs
@@ -37,7 +37,7 @@ namespace VirtoCommerce.XOrder.Data.Commands
 
             var parameters = GetParameters(request);
 
-            var validatePostProcessResult = await paymentInfo.Payment.PaymentMethod.ValidatePostProcessRequestAsync(parameters);
+            var validatePostProcessResult = await paymentInfo.Payment.PaymentMethod.ValidatePostProcessRequestAsync(parameters, cancellationToken);
             if (!validatePostProcessResult.IsSuccess)
             {
                 return ErrorResult<AuthorizePaymentResult>(validatePostProcessResult.ErrorMessage);
@@ -54,7 +54,7 @@ namespace VirtoCommerce.XOrder.Data.Commands
                 Parameters = parameters,
             };
 
-            var processPaymentRequestResult = await paymentInfo.Payment.PaymentMethod.PostProcessPaymentAsync(postProcessPaymentRequest);
+            var processPaymentRequestResult = await paymentInfo.Payment.PaymentMethod.PostProcessPaymentAsync(postProcessPaymentRequest, cancellationToken);
 
             if (processPaymentRequestResult.IsSuccess)
             {

--- a/src/VirtoCommerce.XOrder.Data/Commands/InitializePaymentCommandHandler.cs
+++ b/src/VirtoCommerce.XOrder.Data/Commands/InitializePaymentCommandHandler.cs
@@ -42,7 +42,7 @@ namespace VirtoCommerce.XOrder.Data.Commands
                 Store = paymentInfo.Store,
             };
 
-            var processPaymentResult = paymentInfo.Payment.PaymentMethod.ProcessPayment(processPaymentRequest);
+            var processPaymentResult = await paymentInfo.Payment.PaymentMethod.ProcessPaymentAsync(processPaymentRequest);
 
             var result = new InitializePaymentResult
             {

--- a/src/VirtoCommerce.XOrder.Data/Commands/InitializePaymentCommandHandler.cs
+++ b/src/VirtoCommerce.XOrder.Data/Commands/InitializePaymentCommandHandler.cs
@@ -42,7 +42,7 @@ namespace VirtoCommerce.XOrder.Data.Commands
                 Store = paymentInfo.Store,
             };
 
-            var processPaymentResult = await paymentInfo.Payment.PaymentMethod.ProcessPaymentAsync(processPaymentRequest);
+            var processPaymentResult = await paymentInfo.Payment.PaymentMethod.ProcessPaymentAsync(processPaymentRequest, cancellationToken);
 
             var result = new InitializePaymentResult
             {

--- a/src/VirtoCommerce.XOrder.Data/Commands/ProcessOrderPaymentCommandHandler.cs
+++ b/src/VirtoCommerce.XOrder.Data/Commands/ProcessOrderPaymentCommandHandler.cs
@@ -47,7 +47,7 @@ namespace VirtoCommerce.XOrder.Data.Commands
             };
             var result = await orderAggregate.ProcessOrderPayment(processPaymentRequest, cancellationToken);
 
-            await _customerOrderService.SaveChangesAsync(new[] { orderAggregate.Order });
+            await _customerOrderService.SaveChangesAsync([orderAggregate.Order]);
 
             return result;
         }

--- a/src/VirtoCommerce.XOrder.Data/Commands/ProcessOrderPaymentCommandHandler.cs
+++ b/src/VirtoCommerce.XOrder.Data/Commands/ProcessOrderPaymentCommandHandler.cs
@@ -45,7 +45,7 @@ namespace VirtoCommerce.XOrder.Data.Commands
                 Store = store,
                 BankCardInfo = request.BankCardInfo
             };
-            var result = await orderAggregate.ProcessOrderPayment(processPaymentRequest);
+            var result = await orderAggregate.ProcessOrderPayment(processPaymentRequest, cancellationToken);
 
             await _customerOrderService.SaveChangesAsync(new[] { orderAggregate.Order });
 

--- a/src/VirtoCommerce.XOrder.Data/Commands/ProcessOrderPaymentCommandHandler.cs
+++ b/src/VirtoCommerce.XOrder.Data/Commands/ProcessOrderPaymentCommandHandler.cs
@@ -45,7 +45,7 @@ namespace VirtoCommerce.XOrder.Data.Commands
                 Store = store,
                 BankCardInfo = request.BankCardInfo
             };
-            var result = orderAggregate.ProcessOrderPayment(processPaymentRequest);
+            var result = await orderAggregate.ProcessOrderPayment(processPaymentRequest);
 
             await _customerOrderService.SaveChangesAsync(new[] { orderAggregate.Order });
 

--- a/src/VirtoCommerce.XOrder.Web/module.manifest
+++ b/src/VirtoCommerce.XOrder.Web/module.manifest
@@ -8,7 +8,7 @@
   <dependencies>
     <dependency id="VirtoCommerce.FileExperienceApi" version="3.906.0" />
     <dependency id="VirtoCommerce.Orders" version="3.863.0" />
-    <dependency id="VirtoCommerce.Payment" version="3.813.0-alpha.264-vcst-4564" />
+    <dependency id="VirtoCommerce.Payment" version="3.813.0-alpha.266-vcst-4564" />
     <dependency id="VirtoCommerce.Xapi" version="3.929.0" />
     <dependency id="VirtoCommerce.XCart" version="3.950.0" />
     <dependency id="VirtoCommerce.XCatalog" version="3.942.0" />

--- a/src/VirtoCommerce.XOrder.Web/module.manifest
+++ b/src/VirtoCommerce.XOrder.Web/module.manifest
@@ -8,7 +8,7 @@
   <dependencies>
     <dependency id="VirtoCommerce.FileExperienceApi" version="3.906.0" />
     <dependency id="VirtoCommerce.Orders" version="3.863.0" />
-    <dependency id="VirtoCommerce.Payment" version="3.811.0" />
+    <dependency id="VirtoCommerce.Payment" version="3.813.0-alpha.264-vcst-4564" />
     <dependency id="VirtoCommerce.Xapi" version="3.929.0" />
     <dependency id="VirtoCommerce.XCart" version="3.950.0" />
     <dependency id="VirtoCommerce.XCatalog" version="3.942.0" />

--- a/src/VirtoCommerce.XOrder.Web/module.manifest
+++ b/src/VirtoCommerce.XOrder.Web/module.manifest
@@ -8,7 +8,7 @@
   <dependencies>
     <dependency id="VirtoCommerce.FileExperienceApi" version="3.906.0" />
     <dependency id="VirtoCommerce.Orders" version="3.863.0" />
-    <dependency id="VirtoCommerce.Payment" version="3.813.0-alpha.266-vcst-4564" />
+    <dependency id="VirtoCommerce.Payment" version="3.813.0" />
     <dependency id="VirtoCommerce.Xapi" version="3.929.0" />
     <dependency id="VirtoCommerce.XCart" version="3.950.0" />
     <dependency id="VirtoCommerce.XCatalog" version="3.942.0" />
@@ -46,7 +46,7 @@
   <moduleType>VirtoCommerce.XOrder.Web.Module, VirtoCommerce.XOrder.Web</moduleType>
 
   <releaseNotes>First version.</releaseNotes>
-  <copyright>Copyright © 2024–2025 VirtoCommerce. All rights reserved</copyright>
+  <copyright>Copyright © 2024–2026 VirtoCommerce. All rights reserved</copyright>
   <tags>extension module</tags>
   <useFullTypeNameInSwagger>false</useFullTypeNameInSwagger>
 </module>

--- a/tests/VirtoCommerce.XOrder.Tests/Helpers/Stubs/StubPaymentMethod.cs
+++ b/tests/VirtoCommerce.XOrder.Tests/Helpers/Stubs/StubPaymentMethod.cs
@@ -4,26 +4,10 @@ using VirtoCommerce.PaymentModule.Model.Requests;
 
 namespace VirtoCommerce.XOrder.Tests.Helpers.Stubs
 {
-    public class StubPaymentMethod : PaymentMethod
+    public class StubPaymentMethod(string code) : PaymentMethod(code)
     {
-        public StubPaymentMethod(string code) : base(code)
-        {
-        }
-
         public override PaymentMethodType PaymentMethodType => throw new System.NotImplementedException();
 
         public override PaymentMethodGroupType PaymentMethodGroupType => throw new System.NotImplementedException();
-
-        public override CapturePaymentRequestResult CaptureProcessPayment(CapturePaymentRequest context) => throw new System.NotImplementedException();
-
-        public override PostProcessPaymentRequestResult PostProcessPayment(PostProcessPaymentRequest request) => throw new System.NotImplementedException();
-
-        public override ProcessPaymentRequestResult ProcessPayment(ProcessPaymentRequest request) => throw new System.NotImplementedException();
-
-        public override RefundPaymentRequestResult RefundProcessPayment(RefundPaymentRequest context) => throw new System.NotImplementedException();
-
-        public override ValidatePostProcessRequestResult ValidatePostProcessRequest(NameValueCollection queryString) => throw new System.NotImplementedException();
-
-        public override VoidPaymentRequestResult VoidProcessPayment(VoidPaymentRequest request) => throw new System.NotImplementedException();
     }
 }

--- a/tests/VirtoCommerce.XOrder.Tests/Helpers/Stubs/StubPaymentMethod.cs
+++ b/tests/VirtoCommerce.XOrder.Tests/Helpers/Stubs/StubPaymentMethod.cs
@@ -1,6 +1,4 @@
-using System.Collections.Specialized;
 using VirtoCommerce.PaymentModule.Core.Model;
-using VirtoCommerce.PaymentModule.Model.Requests;
 
 namespace VirtoCommerce.XOrder.Tests.Helpers.Stubs
 {

--- a/tests/VirtoCommerce.XOrder.Tests/ProcessPaymentRequestValidatorTests.cs
+++ b/tests/VirtoCommerce.XOrder.Tests/ProcessPaymentRequestValidatorTests.cs
@@ -207,36 +207,6 @@ namespace VirtoCommerce.XOrder.Tests
             {
             }
 
-            public override ProcessPaymentRequestResult ProcessPayment(ProcessPaymentRequest request)
-            {
-                throw new NotImplementedException();
-            }
-
-            public override PostProcessPaymentRequestResult PostProcessPayment(PostProcessPaymentRequest request)
-            {
-                throw new NotImplementedException();
-            }
-
-            public override VoidPaymentRequestResult VoidProcessPayment(VoidPaymentRequest request)
-            {
-                throw new NotImplementedException();
-            }
-
-            public override CapturePaymentRequestResult CaptureProcessPayment(CapturePaymentRequest context)
-            {
-                throw new NotImplementedException();
-            }
-
-            public override RefundPaymentRequestResult RefundProcessPayment(RefundPaymentRequest context)
-            {
-                throw new NotImplementedException();
-            }
-
-            public override ValidatePostProcessRequestResult ValidatePostProcessRequest(NameValueCollection queryString)
-            {
-                throw new NotImplementedException();
-            }
-
             public override PaymentMethodType PaymentMethodType { get; }
             public override PaymentMethodGroupType PaymentMethodGroupType { get; }
         }

--- a/tests/VirtoCommerce.XOrder.Tests/ProcessPaymentRequestValidatorTests.cs
+++ b/tests/VirtoCommerce.XOrder.Tests/ProcessPaymentRequestValidatorTests.cs
@@ -1,7 +1,5 @@
-using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using VirtoCommerce.OrdersModule.Core.Model;
 using VirtoCommerce.PaymentModule.Core.Model;
 using VirtoCommerce.PaymentModule.Model.Requests;


### PR DESCRIPTION
## Description
feat: Replaced synchronous payment calls with async.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4564
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XOrder_3.915.0-pr-36-9f1f.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core order/payment execution paths by switching to async gateway calls and updating the Payment module dependency, which could affect payment flows if providers rely on old sync behavior or cancellation handling.
> 
> **Overview**
> Payment processing is refactored to use the Payment module’s async APIs end-to-end, including `CustomerOrderAggregate.ProcessOrderPayment` (now async with `CancellationToken`) and the `AuthorizePayment`, `InitializePayment`, and `ProcessOrderPayment` command handlers.
> 
> The module updates its `VirtoCommerce.Payment*` dependency to `3.813.0` and adjusts tests/stubs to match the updated `PaymentMethod` surface; minor cleanups include using collection expressions for `SaveChangesAsync` and updating the manifest copyright year.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f1f0dc92a19ce0af804f589d6c349629af0965f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->