### PR TITLE
Added 'parameters' field to 'initializePayment' command (#33)

### DIFF
--- a/src/VirtoCommerce.XOrder.Core/Commands/AuthorizePaymentCommand.cs
+++ b/src/VirtoCommerce.XOrder.Core/Commands/AuthorizePaymentCommand.cs
@@ -1,4 +1,3 @@
-using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Xapi.Core.Infrastructure;
 using VirtoCommerce.XOrder.Core.Models;
 
@@ -6,6 +5,5 @@ namespace VirtoCommerce.XOrder.Core.Commands
 {
     public class AuthorizePaymentCommand : PaymentCommandBase, ICommand<AuthorizePaymentResult>
     {
-        public KeyValue[] Parameters { get; set; }
     }
 }

--- a/src/VirtoCommerce.XOrder.Core/Commands/PaymentCommandBase.cs
+++ b/src/VirtoCommerce.XOrder.Core/Commands/PaymentCommandBase.cs
@@ -1,3 +1,5 @@
+using VirtoCommerce.Platform.Core.Common;
+
 namespace VirtoCommerce.XOrder.Core.Commands
 {
     public class PaymentCommandBase
@@ -5,5 +7,7 @@ namespace VirtoCommerce.XOrder.Core.Commands
         public string OrderId { get; set; }
 
         public string PaymentId { get; set; }
+
+        public KeyValue[] Parameters { get; set; }
     }
 }

--- a/src/VirtoCommerce.XOrder.Core/Commands/PaymentCommandHandlerBase.cs
+++ b/src/VirtoCommerce.XOrder.Core/Commands/PaymentCommandHandlerBase.cs
@@ -49,7 +49,7 @@ namespace VirtoCommerce.XOrder.Core.Commands
             return result;
         }
 
-        protected static NameValueCollection GetParameters(AuthorizePaymentCommand request)
+        protected static NameValueCollection GetParameters(PaymentCommandBase request)
         {
             var parameters = new NameValueCollection();
             foreach (var param in request?.Parameters ?? [])

--- a/src/VirtoCommerce.XOrder.Core/Schemas/InputInitializePaymentType.cs
+++ b/src/VirtoCommerce.XOrder.Core/Schemas/InputInitializePaymentType.cs
@@ -1,4 +1,5 @@
 using GraphQL.Types;
+using VirtoCommerce.Xapi.Core.Schemas;
 
 namespace VirtoCommerce.XOrder.Core.Schemas
 {
@@ -8,6 +9,7 @@ namespace VirtoCommerce.XOrder.Core.Schemas
         {
             Field<StringGraphType>("orderId").Description("Order Id");
             Field<NonNullGraphType<StringGraphType>>("paymentId").Description("Payment Id");
+            Field<ListGraphType<InputKeyValueType>>("parameters").Description("Input parameters");
         }
     }
 }

--- a/src/VirtoCommerce.XOrder.Data/Commands/InitializePaymentCommandHandler.cs
+++ b/src/VirtoCommerce.XOrder.Data/Commands/InitializePaymentCommandHandler.cs
@@ -32,6 +32,8 @@ namespace VirtoCommerce.XOrder.Data.Commands
                 return ErrorResult<InitializePaymentResult>(validationResult.Errors.FirstOrDefault()?.ErrorMessage);
             }
 
+            var parameters = GetParameters(request);
+
             var processPaymentRequest = new ProcessPaymentRequest
             {
                 OrderId = paymentInfo.CustomerOrder.Id,
@@ -40,6 +42,7 @@ namespace VirtoCommerce.XOrder.Data.Commands
                 Payment = paymentInfo.Payment,
                 StoreId = paymentInfo.Store.Id,
                 Store = paymentInfo.Store,
+                Parameters = parameters,
             };
 
             var processPaymentResult = await paymentInfo.Payment.PaymentMethod.ProcessPaymentAsync(processPaymentRequest, cancellationToken);


### PR DESCRIPTION
## Description
This pull request adds a parameters field to the graphql command initializePayment. This functions the same as with the command authorizePayment, which already had this functionaliry. Some shared logic was moved to the shared base class to prevent code duplication.

This change is relevant as for some payment methods, additional information must be supplied to the external payment provider. For example an Apple Wallet token or Paypal reference id. With this change, these can be supplied from the frontend in the initializePayment call.

## References
### QA-test:
### Jira-link:
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XOrder_3.916.0-pr-37-03b8.zip