### PR TITLE
VCST-4328: Update to .NET10

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <!-- These properties will be shared for all projects -->
   <PropertyGroup>
-    <VersionPrefix>3.917.0</VersionPrefix>
+    <VersionPrefix>3.1000.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <VersionSuffix Condition=" '$(VersionSuffix)' != '' AND '$(BuildNumber)' != '' ">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
   </PropertyGroup>

--- a/src/VirtoCommerce.XOrder.Core/VirtoCommerce.XOrder.Core.csproj
+++ b/src/VirtoCommerce.XOrder.Core/VirtoCommerce.XOrder.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>True</IsPackable>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
@@ -8,11 +8,11 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.863.0" />
-    <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.813.0" />
-    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.929.0" />
-    <PackageReference Include="VirtoCommerce.XCart.Core" Version="3.950.0" />
-    <PackageReference Include="VirtoCommerce.XCatalog.Core" Version="3.942.0" />
+    
+    <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.XCart.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.XCatalog.Core" Version="3.1000.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.XOrder.Data/VirtoCommerce.XOrder.Data.csproj
+++ b/src/VirtoCommerce.XOrder.Data/VirtoCommerce.XOrder.Data.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>True</IsPackable>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
@@ -8,10 +8,10 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.FileExperienceApi.Core" Version="3.906.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.917.0" />
-    <PackageReference Include="VirtoCommerce.XCatalog.Data" Version="3.942.0" />
+    
+    <PackageReference Include="VirtoCommerce.FileExperienceApi.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1002.0" />
+    <PackageReference Include="VirtoCommerce.XCatalog.Data" Version="3.1000.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.XOrder.Core\VirtoCommerce.XOrder.Core.csproj" />

--- a/src/VirtoCommerce.XOrder.Web/VirtoCommerce.XOrder.Web.csproj
+++ b/src/VirtoCommerce.XOrder.Web/VirtoCommerce.XOrder.Web.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/VirtoCommerce.XOrder.Web/module.manifest
+++ b/src/VirtoCommerce.XOrder.Web/module.manifest
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
   <id>VirtoCommerce.XOrder</id>
-  <version>3.917.0</version>
+  <version>3.1000.0</version>
   <version-tag></version-tag>
 
-  <platformVersion>3.917.0</platformVersion>
+  <platformVersion>3.1002.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.FileExperienceApi" version="3.906.0" />
-    <dependency id="VirtoCommerce.Orders" version="3.863.0" />
-    <dependency id="VirtoCommerce.Payment" version="3.813.0" />
-    <dependency id="VirtoCommerce.Xapi" version="3.929.0" />
-    <dependency id="VirtoCommerce.XCart" version="3.950.0" />
-    <dependency id="VirtoCommerce.XCatalog" version="3.942.0" />
+    <dependency id="VirtoCommerce.FileExperienceApi" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Orders" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Payment" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Xapi" version="3.1000.0" />
+    <dependency id="VirtoCommerce.XCart" version="3.1000.0" />
+    <dependency id="VirtoCommerce.XCatalog" version="3.1000.0" />
   </dependencies>
 
   <title>Order Experience API</title>

--- a/tests/VirtoCommerce.XOrder.Tests/Authorization/OrderAuthorizationTests.cs
+++ b/tests/VirtoCommerce.XOrder.Tests/Authorization/OrderAuthorizationTests.cs
@@ -7,6 +7,7 @@ using Moq;
 using VirtoCommerce.CustomerModule.Core.Model;
 using VirtoCommerce.CustomerModule.Core.Services;
 using VirtoCommerce.OrdersModule.Core.Model;
+using VirtoCommerce.Platform.Core.Security;
 using VirtoCommerce.XOrder.Core.Queries;
 using VirtoCommerce.XOrder.Data.Authorization;
 using Xunit;
@@ -19,6 +20,8 @@ namespace VirtoCommerce.XOrder.Tests.Authorization
 
         public OrderAuthorizationTests()
         {
+            ClaimsPrincipalExtensions.UserIdClaimTypes = ["name"];
+
             _memberServiceMock = new Mock<IMemberService>();
 
             _memberServiceMock
@@ -97,9 +100,7 @@ namespace VirtoCommerce.XOrder.Tests.Authorization
         [MemberData(nameof(GetSearchOrderQuery))]
         public async Task CanAccessOrderAuthorizationHandler_SearchOrdersBelongToUser_ShouldSucceed(SearchCustomerOrderQuery query)
         {
-            VirtoCommerce.Platform.Core.Security.ClaimsPrincipalExtensions.UserIdClaimTypes = ["name"];
-
-            //Arrange    
+            //Arrange
             var requirements = new[] { new CanAccessOrderAuthorizationRequirement() };
             var userId = "userId";
             var user = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim("name", userId) }));
@@ -190,9 +191,7 @@ namespace VirtoCommerce.XOrder.Tests.Authorization
         [MemberData(nameof(SearchOrganizationOrderQueryTestData))]
         public async Task CanAccessOrderAuthorizationHandler_SearchOrganizationOrderQuery(SearchOrganizationOrderQuery query, bool succeeded)
         {
-            VirtoCommerce.Platform.Core.Security.ClaimsPrincipalExtensions.UserIdClaimTypes = ["name"];
-
-            //Arrange    
+            //Arrange
             var requirements = new[] { new CanAccessOrderAuthorizationRequirement() };
 
             var user = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim("name", "userId"), new Claim("memberId", "memberId") }));

--- a/tests/VirtoCommerce.XOrder.Tests/VirtoCommerce.XOrder.Tests.csproj
+++ b/tests/VirtoCommerce.XOrder.Tests/VirtoCommerce.XOrder.Tests.csproj
@@ -1,22 +1,22 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="8.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="FluentAssertions" Version="7.2.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\VirtoCommerce.XOrder.Core\VirtoCommerce.XOrder.Core.csproj" />


### PR DESCRIPTION
## Description
Update to .NET10

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4328
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XOrder_3.1000.0-pr-38-0aae.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Framework and dependency upgrades can introduce runtime/build/test compatibility issues across transitive packages, but there are minimal functional code changes beyond test initialization.
> 
> **Overview**
> Upgrades all XOrder projects (Core/Data/Web/Tests) from `net8.0` to `net10.0` and bumps the module version to `3.1000.0` (including `Directory.Build.props` and `module.manifest`, with `platformVersion` moving to `3.1002.0`).
> 
> Aligns VirtoCommerce package/module dependencies to the `3.1000.x` line and refreshes the test stack (e.g., `xunit` -> `xunit.v3`, newer `Microsoft.NET.Test.Sdk`/`coverlet`/`FluentAssertions`), plus a small change in `OrderAuthorizationTests` to set `ClaimsPrincipalExtensions.UserIdClaimTypes` once in the constructor.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0aae07a5a1b421ffa915efe1a4b257addf01a3ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->