### PR TITLE
VCST-4893: Add support for payment localization

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,4 +9,7 @@
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
+  <ItemGroup>
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-rvv3-g6hj-g44x" />
+  </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.XOrder.Core/Commands/PaymentCommandBase.cs
+++ b/src/VirtoCommerce.XOrder.Core/Commands/PaymentCommandBase.cs
@@ -8,6 +8,10 @@ namespace VirtoCommerce.XOrder.Core.Commands
 
         public string PaymentId { get; set; }
 
+        public string StoreId { get; set; }
+
+        public string CultureName { get; set; }
+
         public KeyValue[] Parameters { get; set; }
     }
 }

--- a/src/VirtoCommerce.XOrder.Core/Commands/PaymentCommandHandlerBase.cs
+++ b/src/VirtoCommerce.XOrder.Core/Commands/PaymentCommandHandlerBase.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Specialized;
 using System.Linq;
 using System.Threading.Tasks;
@@ -45,6 +46,13 @@ namespace VirtoCommerce.XOrder.Core.Commands
             }
 
             result.Store = await _storeService.GetByIdAsync(result.CustomerOrder?.StoreId, StoreResponseGroup.StoreInfo.ToString());
+
+            if (!string.IsNullOrEmpty(command.StoreId) &&
+                result.CustomerOrder != null &&
+                !string.Equals(command.StoreId, result.CustomerOrder.StoreId, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException($"Store '{command.StoreId}' does not match order store '{result.CustomerOrder.StoreId}'.");
+            }
 
             return result;
         }

--- a/src/VirtoCommerce.XOrder.Core/Schemas/InputAuthorizePaymentType.cs
+++ b/src/VirtoCommerce.XOrder.Core/Schemas/InputAuthorizePaymentType.cs
@@ -9,6 +9,8 @@ namespace VirtoCommerce.XOrder.Core.Schemas
         {
             Field<StringGraphType>("orderId").Description("Order Id");
             Field<NonNullGraphType<StringGraphType>>("paymentId").Description("Payment Id");
+            Field<StringGraphType>("storeId").Description("Store Id");
+            Field<StringGraphType>("cultureName").Description("Culture name");
             Field<ListGraphType<InputKeyValueType>>("parameters").Description("Input parameters");
         }
     }

--- a/src/VirtoCommerce.XOrder.Core/Schemas/InputInitializePaymentType.cs
+++ b/src/VirtoCommerce.XOrder.Core/Schemas/InputInitializePaymentType.cs
@@ -9,6 +9,8 @@ namespace VirtoCommerce.XOrder.Core.Schemas
         {
             Field<StringGraphType>("orderId").Description("Order Id");
             Field<NonNullGraphType<StringGraphType>>("paymentId").Description("Payment Id");
+            Field<StringGraphType>("storeId").Description("Store Id");
+            Field<StringGraphType>("cultureName").Description("Culture name");
             Field<ListGraphType<InputKeyValueType>>("parameters").Description("Input parameters");
         }
     }

--- a/src/VirtoCommerce.XOrder.Core/VirtoCommerce.XOrder.Core.csproj
+++ b/src/VirtoCommerce.XOrder.Core/VirtoCommerce.XOrder.Core.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.1002.0" />
-    <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.1002.0-alpha.272-vcst-4893-payment-localization" />
+    <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.1002.0" />
     <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1001.0" />
     <PackageReference Include="VirtoCommerce.XCart.Core" Version="3.1001.0" />
     <PackageReference Include="VirtoCommerce.XCatalog.Core" Version="3.1000.0" />

--- a/src/VirtoCommerce.XOrder.Core/VirtoCommerce.XOrder.Core.csproj
+++ b/src/VirtoCommerce.XOrder.Core/VirtoCommerce.XOrder.Core.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.1002.0" />
-    <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.1002.0-alpha.272-vcst-4893-payment-localization" />
     <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1001.0" />
     <PackageReference Include="VirtoCommerce.XCart.Core" Version="3.1001.0" />
     <PackageReference Include="VirtoCommerce.XCatalog.Core" Version="3.1000.0" />

--- a/src/VirtoCommerce.XOrder.Data/Commands/AuthorizePaymentCommandHandler.cs
+++ b/src/VirtoCommerce.XOrder.Data/Commands/AuthorizePaymentCommandHandler.cs
@@ -51,6 +51,9 @@ namespace VirtoCommerce.XOrder.Data.Commands
                 Payment = paymentInfo.Payment,
                 StoreId = paymentInfo.CustomerOrder.StoreId,
                 Store = paymentInfo.Store,
+                CultureName = !string.IsNullOrEmpty(request.CultureName)
+                    ? request.CultureName
+                    : paymentInfo.Store?.DefaultLanguage,
                 Parameters = parameters,
             };
 

--- a/src/VirtoCommerce.XOrder.Data/Commands/InitializePaymentCommandHandler.cs
+++ b/src/VirtoCommerce.XOrder.Data/Commands/InitializePaymentCommandHandler.cs
@@ -42,6 +42,9 @@ namespace VirtoCommerce.XOrder.Data.Commands
                 Payment = paymentInfo.Payment,
                 StoreId = paymentInfo.Store.Id,
                 Store = paymentInfo.Store,
+                CultureName = !string.IsNullOrEmpty(request.CultureName)
+                    ? request.CultureName
+                    : paymentInfo.Store?.DefaultLanguage,
                 Parameters = parameters,
             };
 

--- a/src/VirtoCommerce.XOrder.Web/module.manifest
+++ b/src/VirtoCommerce.XOrder.Web/module.manifest
@@ -8,7 +8,7 @@
   <dependencies>
     <dependency id="VirtoCommerce.FileExperienceApi" version="3.1000.0" />
     <dependency id="VirtoCommerce.Orders" version="3.1002.0" />
-    <dependency id="VirtoCommerce.Payment" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Payment" version="3.1002.0-alpha.272-vcst-4893-payment-localization" />
     <dependency id="VirtoCommerce.Xapi" version="3.1001.0" />
     <dependency id="VirtoCommerce.XCart" version="3.1001.0" />
     <dependency id="VirtoCommerce.XCatalog" version="3.1000.0" />

--- a/src/VirtoCommerce.XOrder.Web/module.manifest
+++ b/src/VirtoCommerce.XOrder.Web/module.manifest
@@ -8,7 +8,7 @@
   <dependencies>
     <dependency id="VirtoCommerce.FileExperienceApi" version="3.1000.0" />
     <dependency id="VirtoCommerce.Orders" version="3.1002.0" />
-    <dependency id="VirtoCommerce.Payment" version="3.1002.0-alpha.272-vcst-4893-payment-localization" />
+    <dependency id="VirtoCommerce.Payment" version="3.1002.0" />
     <dependency id="VirtoCommerce.Xapi" version="3.1001.0" />
     <dependency id="VirtoCommerce.XCart" version="3.1001.0" />
     <dependency id="VirtoCommerce.XCatalog" version="3.1000.0" />


### PR DESCRIPTION
## Description
feat: Adds the support for payment localization

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4893
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XOrder_3.1002.0-pr-41-4d33.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches payment initialization/authorization request construction and adds a store mismatch guard, which can change runtime behavior and potentially break clients relying on previous GraphQL inputs. Dependency bumps and NuGet audit suppression also affect build/runtime compatibility.
> 
> **Overview**
> Adds payment localization support by extending payment command inputs with `storeId` and `cultureName`, exposing these fields in the `authorizePayment`/`initializePayment` GraphQL input types.
> 
> Updates payment handlers to pass `CultureName` into `ProcessPaymentRequest`/`PostProcessPaymentRequest` (falling back to the store default language) and validates that an explicitly provided `storeId` matches the order’s store.
> 
> Bumps `VirtoCommerce.PaymentModule.Core`/module manifest `VirtoCommerce.Payment` dependencies to `3.1002.0` and suppresses a specific NuGet audit advisory (`GHSA-rvv3-g6hj-g44x`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d339a75ee93ccb58a93ac5926b939c5dabe88c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->