### PR TITLE
feat: expose SectionName on order configuration item GraphQL type

### DIFF
--- a/src/VirtoCommerce.XOrder.Core/GlobalSuppressions.cs
+++ b/src/VirtoCommerce.XOrder.Core/GlobalSuppressions.cs
@@ -1,0 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Critical Code Smell", "S1699:Constructors should only call non-overridable methods",
+    Scope = "namespaceanddescendants", Target = "~N:VirtoCommerce.XOrder.Core.Schemas",
+    Justification = "graphql-dotnet schema types build fields via the virtual Field(...) builder in the ctor; subclassed via OverrideGraphType so sealing does not apply.")]

--- a/src/VirtoCommerce.XOrder.Core/Schemas/OrderConfigurationItemType.cs
+++ b/src/VirtoCommerce.XOrder.Core/Schemas/OrderConfigurationItemType.cs
@@ -20,6 +20,7 @@ public class OrderConfigurationItemType : ExtendableGraphType<ConfigurationItem>
     {
         Field(x => x.Id, nullable: false).Description("Configuration item ID");
         Field(x => x.SectionId, nullable: false).Description("Configuration item section ID");
+        Field(x => x.SectionName, nullable: true).Description("Configuration item section name");
         Field(x => x.Name, nullable: true).Description("Configuration item name");
         Field(x => x.ProductId, nullable: true).Description("Configuration item product ID");
         Field(x => x.Sku, nullable: true).Description("Configuration item SKU");

--- a/src/VirtoCommerce.XOrder.Core/VirtoCommerce.XOrder.Core.csproj
+++ b/src/VirtoCommerce.XOrder.Core/VirtoCommerce.XOrder.Core.csproj
@@ -8,7 +8,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.1007.0" />
+    <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.1009.0-alpha.1426-configurationitem-sectionname" />
     <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.1002.0" />
     <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1001.0" />
     <PackageReference Include="VirtoCommerce.XCart.Core" Version="3.1001.0" />

--- a/src/VirtoCommerce.XOrder.Core/VirtoCommerce.XOrder.Core.csproj
+++ b/src/VirtoCommerce.XOrder.Core/VirtoCommerce.XOrder.Core.csproj
@@ -8,10 +8,10 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.1009.0-alpha.1426-configurationitem-sectionname" />
+    <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.1009.0-alpha.1429-configurationitem-sectionname" />
     <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.1002.0" />
     <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1001.0" />
-    <PackageReference Include="VirtoCommerce.XCart.Core" Version="3.1001.0" />
+    <PackageReference Include="VirtoCommerce.XCart.Core" Version="3.1021.0-alpha.264-cartitem-builders" />
     <PackageReference Include="VirtoCommerce.XCatalog.Core" Version="3.1000.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.XOrder.Core/VirtoCommerce.XOrder.Core.csproj
+++ b/src/VirtoCommerce.XOrder.Core/VirtoCommerce.XOrder.Core.csproj
@@ -8,10 +8,10 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.1011.0-alpha.1435-configurationitem-sectionname" />
+    <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.1011.0-alpha.1439-configurationitem-sectionname" />
     <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.1004.0" />
     <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1012.0" />
-    <PackageReference Include="VirtoCommerce.XCart.Core" Version="3.1021.0-alpha.264-cartitem-builders" />
+    <PackageReference Include="VirtoCommerce.XCart.Core" Version="3.1024.0-alpha.279-cartitem-builders" />
     <PackageReference Include="VirtoCommerce.XCatalog.Core" Version="3.1007.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.XOrder.Data/Commands/CreateOrderFromCartCommandHandler.cs
+++ b/src/VirtoCommerce.XOrder.Data/Commands/CreateOrderFromCartCommandHandler.cs
@@ -21,7 +21,6 @@ namespace VirtoCommerce.XOrder.Data.Commands
     {
         private readonly ICustomerOrderAggregateRepository _customerOrderAggregateRepository;
         private readonly ICartAggregateRepository _cartRepository;
-        private readonly ICartValidationContextFactory _cartValidationContextFactory;
         private readonly IMemberService _memberService;
         private readonly IMediator _mediator;
 
@@ -31,13 +30,11 @@ namespace VirtoCommerce.XOrder.Data.Commands
             IShoppingCartService cartService,
             ICustomerOrderAggregateRepository customerOrderAggregateRepository,
             ICartAggregateRepository cartRepository,
-            ICartValidationContextFactory cartValidationContextFactory,
             IMemberService memberService,
             IMediator mediator)
         {
             _customerOrderAggregateRepository = customerOrderAggregateRepository;
             _cartRepository = cartRepository;
-            _cartValidationContextFactory = cartValidationContextFactory;
             _memberService = memberService;
             _mediator = mediator;
         }
@@ -77,8 +74,7 @@ namespace VirtoCommerce.XOrder.Data.Commands
 
         protected virtual async Task ValidateCart(CartAggregate cartAggregate)
         {
-            var context = await _cartValidationContextFactory.CreateValidationContextAsync(cartAggregate, cartAggregate.CartProducts.Select(x => x.Value).ToList());
-            await cartAggregate.ValidateAsync(context, ValidationRuleSet);
+            await cartAggregate.ValidateAsync(ValidationRuleSet);
 
             var errors = cartAggregate.GetValidationErrors();
             if (errors.Any())

--- a/src/VirtoCommerce.XOrder.Web/module.manifest
+++ b/src/VirtoCommerce.XOrder.Web/module.manifest
@@ -7,10 +7,10 @@
   <platformVersion>3.1016.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.FileExperienceApi" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Orders" version="3.1009.0-alpha.1426-configurationitem-sectionname" />
+    <dependency id="VirtoCommerce.Orders" version="3.1009.0-alpha.1429-configurationitem-sectionname" />
     <dependency id="VirtoCommerce.Payment" version="3.1002.0" />
     <dependency id="VirtoCommerce.Xapi" version="3.1001.0" />
-    <dependency id="VirtoCommerce.XCart" version="3.1001.0" />
+    <dependency id="VirtoCommerce.XCart" version="3.1021.0-alpha.264-cartitem-builders" />
     <dependency id="VirtoCommerce.XCatalog" version="3.1000.0" />
   </dependencies>
 

--- a/src/VirtoCommerce.XOrder.Web/module.manifest
+++ b/src/VirtoCommerce.XOrder.Web/module.manifest
@@ -7,7 +7,7 @@
   <platformVersion>3.1016.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.FileExperienceApi" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Orders" version="3.1007.0" />
+    <dependency id="VirtoCommerce.Orders" version="3.1009.0-alpha.1426-configurationitem-sectionname" />
     <dependency id="VirtoCommerce.Payment" version="3.1002.0" />
     <dependency id="VirtoCommerce.Xapi" version="3.1001.0" />
     <dependency id="VirtoCommerce.XCart" version="3.1001.0" />

--- a/src/VirtoCommerce.XOrder.Web/module.manifest
+++ b/src/VirtoCommerce.XOrder.Web/module.manifest
@@ -7,10 +7,10 @@
   <platformVersion>3.1039.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.FileExperienceApi" version="3.1003.0" />
-    <dependency id="VirtoCommerce.Orders" version="3.1011.0-alpha.1435-configurationitem-sectionname" />
+    <dependency id="VirtoCommerce.Orders" version="3.1011.0-alpha.1439-configurationitem-sectionname" />
     <dependency id="VirtoCommerce.Payment" version="3.1004.0" />
     <dependency id="VirtoCommerce.Xapi" version="3.1012.0" />
-    <dependency id="VirtoCommerce.XCart" version="3.1021.0-alpha.264-cartitem-builders" />
+    <dependency id="VirtoCommerce.XCart" version="3.1024.0-alpha.279-cartitem-builders" />
     <dependency id="VirtoCommerce.XCatalog" version="3.1007.0" />
   </dependencies>
 

--- a/tests/VirtoCommerce.XOrder.Tests/Handlers/CreateOrderFromCartCommandHandlerTests.cs
+++ b/tests/VirtoCommerce.XOrder.Tests/Handlers/CreateOrderFromCartCommandHandlerTests.cs
@@ -107,18 +107,21 @@ namespace VirtoCommerce.XOrder.Tests.Handlers
             var cartService = new Mock<IShoppingCartService>();
 
             var customerAggrRep = new Mock<ICustomerOrderAggregateRepository>();
-            customerAggrRep.Setup(x => x.CreateOrderFromCart(It.IsAny<ShoppingCart>()))
+            customerAggrRep
+                .Setup(x => x.CreateOrderFromCart(It.IsAny<ShoppingCart>()))
                 .ReturnsAsync(new CustomerOrderAggregate(null, null));
 
             var contextFactory = new Mock<ICartValidationContextFactory>();
-            contextFactory.Setup(x => x.CreateValidationContextAsync(It.IsAny<CartAggregate>()))
+            contextFactory
+                .Setup(x => x.CreateValidationContextAsync(It.IsAny<CartAggregate>()))
                 .ReturnsAsync(new CartValidationContext());
 
             var cartAggregate = new CartAggregate(null, null, null, null, null, null, null, null, null, null, null, contextFactory.Object, Mock.Of<ICartItemBuilder>());
             cartAggregate.GrabCart(cart, new Store(), new Contact(), new Currency());
 
             var cartAggrRepository = new Mock<ICartAggregateRepository>();
-            cartAggrRepository.Setup(x => x.GetCartForShoppingCartAsync(It.IsAny<ShoppingCart>(), null))
+            cartAggrRepository
+                .Setup(x => x.GetCartForShoppingCartAsync(It.IsAny<ShoppingCart>(), null))
                 .ReturnsAsync(cartAggregate);
 
             var mediatorMock = new Mock<IMediator>();
@@ -148,7 +151,8 @@ namespace VirtoCommerce.XOrder.Tests.Handlers
         private static CartAggregate GetCartAggregateMock(ShoppingCart cart)
         {
             var validationContextFactory = new Mock<ICartValidationContextFactory>();
-            validationContextFactory.Setup(x => x.CreateValidationContextAsync(It.IsAny<CartAggregate>()))
+            validationContextFactory
+                .Setup(x => x.CreateValidationContextAsync(It.IsAny<CartAggregate>()))
                 .ReturnsAsync(new CartValidationContext());
 
             var cartAggregate = new CartAggregate(

--- a/tests/VirtoCommerce.XOrder.Tests/Handlers/CreateOrderFromCartCommandHandlerTests.cs
+++ b/tests/VirtoCommerce.XOrder.Tests/Handlers/CreateOrderFromCartCommandHandlerTests.cs
@@ -5,6 +5,8 @@ using System.Threading.Tasks;
 using AutoFixture;
 using AutoMapper;
 using FluentAssertions;
+using FluentValidation.Internal;
+using FluentValidation.Results;
 using GraphQL;
 using MediatR;
 using Moq;
@@ -116,7 +118,12 @@ namespace VirtoCommerce.XOrder.Tests.Handlers
                 .Setup(x => x.CreateValidationContextAsync(It.IsAny<CartAggregate>()))
                 .ReturnsAsync(new CartValidationContext());
 
-            var cartAggregate = new CartAggregate(null, null, null, null, null, null, null, null, null, null, null, contextFactory.Object, Mock.Of<ICartItemBuilder>());
+            var validatorRegistry = new Mock<ICartValidatorRegistry>();
+            validatorRegistry
+                .Setup(x => x.ValidateAsync(It.IsAny<CartValidationContext>(), It.IsAny<Action<ValidationStrategy<CartValidationContext>>>()))
+                .ReturnsAsync(new List<ValidationFailure>());
+
+            var cartAggregate = new CartAggregate(null, null, null, null, null, null, null, null, null, null, contextFactory.Object, Mock.Of<ICartItemBuilder>(), validatorRegistry.Object);
             cartAggregate.GrabCart(cart, new Store(), new Contact(), new Currency());
 
             var cartAggrRepository = new Mock<ICartAggregateRepository>();
@@ -155,6 +162,14 @@ namespace VirtoCommerce.XOrder.Tests.Handlers
                 .Setup(x => x.CreateValidationContextAsync(It.IsAny<CartAggregate>()))
                 .ReturnsAsync(new CartValidationContext());
 
+            // Registry reports a cart-level validation failure so ValidateAsync populates
+            // CartValidationErrors — the trigger for CreateOrderFromCartCommandHandler.ValidateCart
+            // to throw ExecutionError.
+            var validatorRegistry = new Mock<ICartValidatorRegistry>();
+            validatorRegistry
+                .Setup(x => x.ValidateAsync(It.IsAny<CartValidationContext>(), It.IsAny<Action<ValidationStrategy<CartValidationContext>>>()))
+                .ReturnsAsync(new List<ValidationFailure> { new("Cart", "Cart has validation errors") { ErrorCode = "CART_HAS_ERRORS" } });
+
             var cartAggregate = new CartAggregate(
                 Mock.Of<IMarketingPromoEvaluator>(),
                 Mock.Of<IShoppingCartTotalsCalculator>(),
@@ -164,11 +179,11 @@ namespace VirtoCommerce.XOrder.Tests.Handlers
                 Mock.Of<IMapper>(),
                 Mock.Of<IMemberService>(),
                 Mock.Of<IGenericPipelineLauncher>(),
-                Mock.Of<IConfigurationItemValidator>(),
                 Mock.Of<IFileUploadService>(),
                 Mock.Of<ICartSharingService>(),
                 validationContextFactory.Object,
-                Mock.Of<ICartItemBuilder>());
+                Mock.Of<ICartItemBuilder>(),
+                validatorRegistry.Object);
 
             var contact = new Contact()
             {

--- a/tests/VirtoCommerce.XOrder.Tests/Handlers/CreateOrderFromCartCommandHandlerTests.cs
+++ b/tests/VirtoCommerce.XOrder.Tests/Handlers/CreateOrderFromCartCommandHandlerTests.cs
@@ -59,10 +59,6 @@ namespace VirtoCommerce.XOrder.Tests.Handlers
                     return cartAggregate;
                 });
 
-            var validationContextMock = new Mock<ICartValidationContextFactory>();
-            validationContextMock.Setup(x => x.CreateValidationContextAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<CartProduct>>()))
-                .ReturnsAsync(new CartValidationContext());
-
             var orderAggregateRepositoryMock = new Mock<ICustomerOrderAggregateRepository>();
 
             var memberService = new Mock<IMemberService>();
@@ -74,7 +70,6 @@ namespace VirtoCommerce.XOrder.Tests.Handlers
                 cartService.Object,
                 orderAggregateRepositoryMock.Object,
                 aggregationService.Object,
-                validationContextMock.Object,
                 memberService.Object,
                 mediatorMock.Object);
 
@@ -115,16 +110,16 @@ namespace VirtoCommerce.XOrder.Tests.Handlers
             customerAggrRep.Setup(x => x.CreateOrderFromCart(It.IsAny<ShoppingCart>()))
                 .ReturnsAsync(new CustomerOrderAggregate(null, null));
 
-            var cartAggregate = new CartAggregate(null, null, null, null, null, null, null, null, null, null, null);
+            var contextFactory = new Mock<ICartValidationContextFactory>();
+            contextFactory.Setup(x => x.CreateValidationContextAsync(It.IsAny<CartAggregate>()))
+                .ReturnsAsync(new CartValidationContext());
+
+            var cartAggregate = new CartAggregate(null, null, null, null, null, null, null, null, null, null, null, contextFactory.Object, Mock.Of<ICartItemBuilder>());
             cartAggregate.GrabCart(cart, new Store(), new Contact(), new Currency());
 
             var cartAggrRepository = new Mock<ICartAggregateRepository>();
             cartAggrRepository.Setup(x => x.GetCartForShoppingCartAsync(It.IsAny<ShoppingCart>(), null))
                 .ReturnsAsync(cartAggregate);
-
-            var contextFactory = new Mock<ICartValidationContextFactory>();
-            contextFactory.Setup(x => x.CreateValidationContextAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<CartProduct>>()))
-                .ReturnsAsync(new CartValidationContext());
 
             var mediatorMock = new Mock<IMediator>();
             mediatorMock
@@ -137,7 +132,6 @@ namespace VirtoCommerce.XOrder.Tests.Handlers
                 cartService.Object,
                 customerAggrRep.Object,
                 cartAggrRepository.Object,
-                contextFactory.Object,
                 memberService.Object,
                 mediatorMock.Object)
             {
@@ -153,6 +147,10 @@ namespace VirtoCommerce.XOrder.Tests.Handlers
 
         private static CartAggregate GetCartAggregateMock(ShoppingCart cart)
         {
+            var validationContextFactory = new Mock<ICartValidationContextFactory>();
+            validationContextFactory.Setup(x => x.CreateValidationContextAsync(It.IsAny<CartAggregate>()))
+                .ReturnsAsync(new CartValidationContext());
+
             var cartAggregate = new CartAggregate(
                 Mock.Of<IMarketingPromoEvaluator>(),
                 Mock.Of<IShoppingCartTotalsCalculator>(),
@@ -164,7 +162,9 @@ namespace VirtoCommerce.XOrder.Tests.Handlers
                 Mock.Of<IGenericPipelineLauncher>(),
                 Mock.Of<IConfigurationItemValidator>(),
                 Mock.Of<IFileUploadService>(),
-                Mock.Of<ICartSharingService>());
+                Mock.Of<ICartSharingService>(),
+                validationContextFactory.Object,
+                Mock.Of<ICartItemBuilder>());
 
             var contact = new Contact()
             {


### PR DESCRIPTION
## Description

Expose the configuration section name on the order configuration-item GraphQL type, and align x-order with the new XCart cart-aggregate validation API.

- Add the `sectionName` field to `OrderConfigurationItemType`, surfacing the denormalized `ConfigurationItem.SectionName` persisted by OrdersModule — symmetric with the `sectionName` field on `CartConfigurationItemType`.

- **`CreateOrderFromCartCommandHandler` — migrate to `CartAggregate.ValidateAsync(string ruleSet)`.** XCart's per-ruleSet validation refactor obsoleted (as an error, `VC0009`) the `ValidateAsync(CartValidationContext, ruleSet)` overload; the validation context is now created internally by the aggregate. `ValidateCart` now calls `cartAggregate.ValidateAsync(ValidationRuleSet)` directly, and the handler no longer injects `ICartValidationContextFactory` (the factory dependency moves from the consumer to the aggregate's DI). No behavioural change to which validation rules run or how errors surface — only where the context is built.

- **Tests** updated for the above: `CreateOrderFromCartCommandHandler` is constructed without the factory argument, and the test `CartAggregate` instances are built via the new constructor (which now also takes `ICartItemBuilder`), wiring an `ICartValidationContextFactory` mock into the aggregate so `ValidateAsync(ruleSet)` resolves its context.

## Dependencies

Pins the sibling branch alpha builds — replace with released versions before merge:

- `VirtoCommerce.OrdersModule.Core` / `VirtoCommerce.Orders` → `3.1009.0-alpha.1429-configurationitem-sectionname` (for `ConfigurationItem.SectionName`).
- `VirtoCommerce.XCart.Core` / `VirtoCommerce.XCart` → `3.1021.0-alpha.264-cartitem-builders` (the new `ValidateAsync(ruleSet)` API and the `ICartItemBuilder` constructor parameter). The validation-API migration above is required to compile against this build.

## References
### QA-test:
### Jira-link:
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XOrder_3.1007.0-pr-44-950b.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches order GraphQL schema and pins prerelease Orders/XCart dependencies; test-only changes to cart validation wiring with limited production logic in this diff.
> 
> **Overview**
> Exposes **`sectionName`** on **`OrderConfigurationItemType`**, mapping the denormalized `ConfigurationItem.SectionName` from Orders (aligned with cart configuration items).
> 
> **Dependency alignment:** bumps **`VirtoCommerce.OrdersModule.Core`** / **`VirtoCommerce.Orders`** and **`VirtoCommerce.XCart.Core`** / **`VirtoCommerce.XCart`** to alpha builds that supply `SectionName` and the updated cart aggregate surface (`ICartItemBuilder`, `ICartValidatorRegistry`-style validation).
> 
> Adds a **Sonar S1699 suppression** for GraphQL schema types under `VirtoCommerce.XOrder.Core.Schemas` (virtual `Field(...)` in constructors).
> 
> **Tests:** `CreateOrderFromCartCommandHandlerTests` construct **`CartAggregate`** with `ICartValidationContextFactory`, **`ICartItemBuilder`**, and **`ICartValidatorRegistry`** mocks instead of the older `IConfigurationItemValidator` / slimmer ctor wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 950bcddb3a29d6af06a3b8435c25dc947445bc7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

