### PR TITLE
VCST-5163: Stable 15 — XOrder (platform 3.1039.0)

### DIFF
--- a/src/VirtoCommerce.XOrder.Core/VirtoCommerce.XOrder.Core.csproj
+++ b/src/VirtoCommerce.XOrder.Core/VirtoCommerce.XOrder.Core.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>True</IsPackable>
@@ -8,10 +8,10 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.1007.0" />
-    <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.1002.0" />
-    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1001.0" />
-    <PackageReference Include="VirtoCommerce.XCart.Core" Version="3.1001.0" />
-    <PackageReference Include="VirtoCommerce.XCatalog.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.1009.0" />
+    <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.1004.0" />
+    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1012.0" />
+    <PackageReference Include="VirtoCommerce.XCart.Core" Version="3.1021.0" />
+    <PackageReference Include="VirtoCommerce.XCatalog.Core" Version="3.1007.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.XOrder.Data/Commands/CreateOrderFromCartCommandHandler.cs
+++ b/src/VirtoCommerce.XOrder.Data/Commands/CreateOrderFromCartCommandHandler.cs
@@ -10,7 +10,6 @@ using VirtoCommerce.Xapi.Core.Helpers;
 using VirtoCommerce.XCart.Core;
 using VirtoCommerce.XCart.Core.Queries;
 using VirtoCommerce.XCart.Core.Services;
-using VirtoCommerce.XCart.Core.Validators;
 using VirtoCommerce.XOrder.Core;
 using VirtoCommerce.XOrder.Core.Commands;
 using VirtoCommerce.XOrder.Core.Services;
@@ -21,7 +20,6 @@ namespace VirtoCommerce.XOrder.Data.Commands
     {
         private readonly ICustomerOrderAggregateRepository _customerOrderAggregateRepository;
         private readonly ICartAggregateRepository _cartRepository;
-        private readonly ICartValidationContextFactory _cartValidationContextFactory;
         private readonly IMemberService _memberService;
         private readonly IMediator _mediator;
 
@@ -31,13 +29,11 @@ namespace VirtoCommerce.XOrder.Data.Commands
             IShoppingCartService cartService,
             ICustomerOrderAggregateRepository customerOrderAggregateRepository,
             ICartAggregateRepository cartRepository,
-            ICartValidationContextFactory cartValidationContextFactory,
             IMemberService memberService,
             IMediator mediator)
         {
             _customerOrderAggregateRepository = customerOrderAggregateRepository;
             _cartRepository = cartRepository;
-            _cartValidationContextFactory = cartValidationContextFactory;
             _memberService = memberService;
             _mediator = mediator;
         }
@@ -77,8 +73,7 @@ namespace VirtoCommerce.XOrder.Data.Commands
 
         protected virtual async Task ValidateCart(CartAggregate cartAggregate)
         {
-            var context = await _cartValidationContextFactory.CreateValidationContextAsync(cartAggregate, cartAggregate.CartProducts.Select(x => x.Value).ToList());
-            await cartAggregate.ValidateAsync(context, ValidationRuleSet);
+            await cartAggregate.ValidateAsync(ValidationRuleSet);
 
             var errors = cartAggregate.GetValidationErrors();
             if (errors.Any())

--- a/src/VirtoCommerce.XOrder.Data/VirtoCommerce.XOrder.Data.csproj
+++ b/src/VirtoCommerce.XOrder.Data/VirtoCommerce.XOrder.Data.csproj
@@ -8,9 +8,9 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.FileExperienceApi.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1016.0" />
-    <PackageReference Include="VirtoCommerce.XCatalog.Data" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.FileExperienceApi.Core" Version="3.1003.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.XCatalog.Data" Version="3.1007.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.XOrder.Core\VirtoCommerce.XOrder.Core.csproj" />

--- a/src/VirtoCommerce.XOrder.Web/module.manifest
+++ b/src/VirtoCommerce.XOrder.Web/module.manifest
@@ -4,14 +4,14 @@
   <version>3.1005.0</version>
   <version-tag></version-tag>
 
-  <platformVersion>3.1016.0</platformVersion>
+  <platformVersion>3.1039.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.FileExperienceApi" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Orders" version="3.1007.0" />
-    <dependency id="VirtoCommerce.Payment" version="3.1002.0" />
-    <dependency id="VirtoCommerce.Xapi" version="3.1001.0" />
-    <dependency id="VirtoCommerce.XCart" version="3.1001.0" />
-    <dependency id="VirtoCommerce.XCatalog" version="3.1000.0" />
+    <dependency id="VirtoCommerce.FileExperienceApi" version="3.1003.0" />
+    <dependency id="VirtoCommerce.Orders" version="3.1009.0" />
+    <dependency id="VirtoCommerce.Payment" version="3.1004.0" />
+    <dependency id="VirtoCommerce.Xapi" version="3.1012.0" />
+    <dependency id="VirtoCommerce.XCart" version="3.1021.0" />
+    <dependency id="VirtoCommerce.XCatalog" version="3.1007.0" />
   </dependencies>
 
   <title>Order Experience API</title>

--- a/tests/VirtoCommerce.XOrder.Tests/Handlers/CreateOrderFromCartCommandHandlerTests.cs
+++ b/tests/VirtoCommerce.XOrder.Tests/Handlers/CreateOrderFromCartCommandHandlerTests.cs
@@ -59,10 +59,6 @@ namespace VirtoCommerce.XOrder.Tests.Handlers
                     return cartAggregate;
                 });
 
-            var validationContextMock = new Mock<ICartValidationContextFactory>();
-            validationContextMock.Setup(x => x.CreateValidationContextAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<CartProduct>>()))
-                .ReturnsAsync(new CartValidationContext());
-
             var orderAggregateRepositoryMock = new Mock<ICustomerOrderAggregateRepository>();
 
             var memberService = new Mock<IMemberService>();
@@ -74,7 +70,6 @@ namespace VirtoCommerce.XOrder.Tests.Handlers
                 cartService.Object,
                 orderAggregateRepositoryMock.Object,
                 aggregationService.Object,
-                validationContextMock.Object,
                 memberService.Object,
                 mediatorMock.Object);
 
@@ -115,16 +110,16 @@ namespace VirtoCommerce.XOrder.Tests.Handlers
             customerAggrRep.Setup(x => x.CreateOrderFromCart(It.IsAny<ShoppingCart>()))
                 .ReturnsAsync(new CustomerOrderAggregate(null, null));
 
-            var cartAggregate = new CartAggregate(null, null, null, null, null, null, null, null, null, null, null);
+            var validationContextFactory = new Mock<ICartValidationContextFactory>();
+            validationContextFactory.Setup(x => x.CreateValidationContextAsync(It.IsAny<CartAggregate>()))
+                .ReturnsAsync(new CartValidationContext());
+
+            var cartAggregate = new CartAggregate(null, null, null, null, null, null, null, null, null, null, null, validationContextFactory.Object);
             cartAggregate.GrabCart(cart, new Store(), new Contact(), new Currency());
 
             var cartAggrRepository = new Mock<ICartAggregateRepository>();
             cartAggrRepository.Setup(x => x.GetCartForShoppingCartAsync(It.IsAny<ShoppingCart>(), null))
                 .ReturnsAsync(cartAggregate);
-
-            var contextFactory = new Mock<ICartValidationContextFactory>();
-            contextFactory.Setup(x => x.CreateValidationContextAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<CartProduct>>()))
-                .ReturnsAsync(new CartValidationContext());
 
             var mediatorMock = new Mock<IMediator>();
             mediatorMock
@@ -137,7 +132,6 @@ namespace VirtoCommerce.XOrder.Tests.Handlers
                 cartService.Object,
                 customerAggrRep.Object,
                 cartAggrRepository.Object,
-                contextFactory.Object,
                 memberService.Object,
                 mediatorMock.Object)
             {
@@ -164,7 +158,9 @@ namespace VirtoCommerce.XOrder.Tests.Handlers
                 Mock.Of<IGenericPipelineLauncher>(),
                 Mock.Of<IConfigurationItemValidator>(),
                 Mock.Of<IFileUploadService>(),
-                Mock.Of<ICartSharingService>());
+                Mock.Of<ICartSharingService>(),
+                Mock.Of<ICartValidationContextFactory>(x =>
+                    x.CreateValidationContextAsync(It.IsAny<CartAggregate>()) == Task.FromResult(new CartValidationContext())));
 
             var contact = new Contact()
             {

--- a/tests/VirtoCommerce.XOrder.Tests/VirtoCommerce.XOrder.Tests.csproj
+++ b/tests/VirtoCommerce.XOrder.Tests/VirtoCommerce.XOrder.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="coverlet.collector" Version="8.0.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Part of **Stable 15** (Wave 10). Builds against published platform [3.1039.0](https://github.com/VirtoCommerce/vc-platform/releases/tag/3.1039.0) + Waves 1–9 packages on nuget.org. Version handled by CI.

- Xapi dep bumped to 3.1012.0.
- `vc-build Compress` green incl. unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches checkout order creation and cart validation behavior against upgraded XCart packages; risk is moderate but localized to the create-order path.
> 
> **Overview**
> Aligns **XOrder** with **Stable 15** by raising `module.manifest` and NuGet references to platform **3.1039.0** and updated Xapi/XCart/XCatalog/Orders/Payment/FileExperienceApi packages.
> 
> **Order-from-cart validation** is updated for **XCart 3.1021.0**: `CreateOrderFromCartCommandHandler` drops `ICartValidationContextFactory` and calls `cartAggregate.ValidateAsync(ValidationRuleSet)` instead of building a context from cart products. Unit tests construct `CartAggregate` with the factory (new `CreateValidationContextAsync(CartAggregate)` overload) while the handler mocks no longer wire the factory in.
> 
> Also bumps test **coverlet.collector** to 10.0.1 and removes a BOM from `VirtoCommerce.XOrder.Core.csproj`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7111ccecb54e0fb0afe571a7ccc7c11dbd037921. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5163
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XOrder_3.1005.0-pr-45-7111.zip