### PR TITLE
VCST-5104: Mixed currency line items support

### DIFF
--- a/src/VirtoCommerce.XOrder.Core/CustomerOrderAggregate.cs
+++ b/src/VirtoCommerce.XOrder.Core/CustomerOrderAggregate.cs
@@ -16,6 +16,7 @@ using VirtoCommerce.Platform.Core.Domain;
 using VirtoCommerce.StoreModule.Core.Model;
 using VirtoCommerce.Xapi.Core.Models;
 using VirtoCommerce.Xapi.Core.Services;
+using VirtoCommerce.XOrder.Core.Models;
 using VirtoCommerce.XOrder.Core.Validators;
 
 namespace VirtoCommerce.XOrder.Core
@@ -33,14 +34,34 @@ namespace VirtoCommerce.XOrder.Core
         }
 
         public CustomerOrder Order { get; protected set; }
+
         public Currency Currency { get; protected set; }
+
+        public IList<Currency> CurrencyList { get; protected set; }
 
         public Store Store { get; protected set; }
 
-        public CustomerOrderAggregate GrabCustomerOrder(CustomerOrder order, Currency currency, Store store)
+        public IList<OrderTotalAggregate> OrderTotals
+        {
+            get
+            {
+                var orderTotals = Order.OrderTotals?.Select(x => new OrderTotalAggregate() { OrderTotal = x }).ToList() ?? [];
+
+                foreach (var item in orderTotals)
+                {
+                    item.IsDefaultTotalCurrency = Order.Currency.EqualsIgnoreCase(item.OrderTotal.CurrencyCode);
+                    item.Currency = CurrencyList?.FirstOrDefault(x => x.Code.EqualsIgnoreCase(item.OrderTotal.CurrencyCode)) ?? Currency;
+                }
+
+                return orderTotals;
+            }
+        }
+
+        public CustomerOrderAggregate GrabCustomerOrder(CustomerOrder order, Currency mainCurrency, IList<Currency> currencyList, Store store)
         {
             Order = order;
-            Currency = currency;
+            Currency = mainCurrency;
+            CurrencyList = currencyList;
             Store = store;
 
             return this;

--- a/src/VirtoCommerce.XOrder.Core/CustomerOrderAggregate.cs
+++ b/src/VirtoCommerce.XOrder.Core/CustomerOrderAggregate.cs
@@ -37,7 +37,7 @@ namespace VirtoCommerce.XOrder.Core
 
         public Currency Currency { get; protected set; }
 
-        public IList<Currency> CurrencyList { get; protected set; }
+        public IList<Currency> AllCurrencies { get; protected set; }
 
         public Store Store { get; protected set; }
 
@@ -50,7 +50,7 @@ namespace VirtoCommerce.XOrder.Core
                 foreach (var item in orderTotals)
                 {
                     item.IsDefaultTotalCurrency = Order.Currency.EqualsIgnoreCase(item.OrderTotal.CurrencyCode);
-                    item.Currency = CurrencyList?.FirstOrDefault(x => x.Code.EqualsIgnoreCase(item.OrderTotal.CurrencyCode)) ?? Currency;
+                    item.Currency = AllCurrencies?.FirstOrDefault(x => x.Code.EqualsIgnoreCase(item.OrderTotal.CurrencyCode)) ?? Currency;
                 }
 
                 return orderTotals;
@@ -61,7 +61,7 @@ namespace VirtoCommerce.XOrder.Core
         {
             Order = order;
             Currency = mainCurrency;
-            CurrencyList = currencyList;
+            AllCurrencies = currencyList;
             Store = store;
 
             return this;

--- a/src/VirtoCommerce.XOrder.Core/Extensions/ResolveFieldContextExtensions.cs
+++ b/src/VirtoCommerce.XOrder.Core/Extensions/ResolveFieldContextExtensions.cs
@@ -84,8 +84,13 @@ namespace VirtoCommerce.XOrder.Core.Extensions
         public static Currency GetConfiguratonItemCurrency(this IResolveFieldContext<ConfigurationItem> context)
         {
             var order = context.GetOrder();
+            if (order == null)
+            {
+                return null;
+            }
+
             var lineItemId = context.Source.LineItemId;
-            var lineItem = order?.Order?.Items?.FirstOrDefault(x => x.Id == lineItemId);
+            var lineItem = order.Order?.Items?.FirstOrDefault(x => x.Id == lineItemId);
             if (lineItem == null)
             {
                 return null;

--- a/src/VirtoCommerce.XOrder.Core/Extensions/ResolveFieldContextExtensions.cs
+++ b/src/VirtoCommerce.XOrder.Core/Extensions/ResolveFieldContextExtensions.cs
@@ -65,10 +65,12 @@ namespace VirtoCommerce.XOrder.Core.Extensions
             }
         }
 
-        public static Currency GetLineItemCurrency(this IResolveFieldContext<LineItem> userContext)
+        public static Currency GetConfiguratonItemCurrency(this IResolveFieldContext<ConfigurationItem> context)
         {
-            var order = userContext.GetOrder();
-            return order?.CurrencyList?.FirstOrDefault(x => x.Code.EqualsIgnoreCase(userContext.Source.Currency)) ?? order?.Currency;
+            var order = context.GetOrder();
+            var lineItemId = context.Source.LineItemId;
+            var lineItem = order?.Order.Items.FirstOrDefault(x => x.Id == lineItemId);
+            return context.GetCurrencyByCode(lineItem?.Currency);
         }
     }
 }

--- a/src/VirtoCommerce.XOrder.Core/Extensions/ResolveFieldContextExtensions.cs
+++ b/src/VirtoCommerce.XOrder.Core/Extensions/ResolveFieldContextExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using GraphQL;
 using VirtoCommerce.CoreModule.Core.Currency;
+using VirtoCommerce.OrdersModule.Core.Model;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Xapi.Core.Extensions;
 using VirtoCommerce.Xapi.Core.Infrastructure;
@@ -62,6 +63,12 @@ namespace VirtoCommerce.XOrder.Core.Extensions
 
                 return result ?? throw new OperationCanceledException($"the currency with code '{currencyCode}' is not registered");
             }
+        }
+
+        public static Currency GetLineItemCurrency(this IResolveFieldContext<LineItem> userContext)
+        {
+            var order = userContext.GetOrder();
+            return order?.CurrencyList?.FirstOrDefault(x => x.Code.EqualsIgnoreCase(userContext.Source.Currency)) ?? order.Currency;
         }
     }
 }

--- a/src/VirtoCommerce.XOrder.Core/Extensions/ResolveFieldContextExtensions.cs
+++ b/src/VirtoCommerce.XOrder.Core/Extensions/ResolveFieldContextExtensions.cs
@@ -68,7 +68,7 @@ namespace VirtoCommerce.XOrder.Core.Extensions
         public static Currency GetLineItemCurrency(this IResolveFieldContext<LineItem> userContext)
         {
             var order = userContext.GetOrder();
-            return order?.CurrencyList?.FirstOrDefault(x => x.Code.EqualsIgnoreCase(userContext.Source.Currency)) ?? order.Currency;
+            return order?.CurrencyList?.FirstOrDefault(x => x.Code.EqualsIgnoreCase(userContext.Source.Currency)) ?? order?.Currency;
         }
     }
 }

--- a/src/VirtoCommerce.XOrder.Core/Extensions/ResolveFieldContextExtensions.cs
+++ b/src/VirtoCommerce.XOrder.Core/Extensions/ResolveFieldContextExtensions.cs
@@ -65,12 +65,38 @@ namespace VirtoCommerce.XOrder.Core.Extensions
             }
         }
 
+        public static Currency GetOrderItemCurrency(this IResolveFieldContext<LineItem> context)
+        {
+            var order = context.GetOrder();
+            if (order == null)
+            {
+                return null;
+            }
+
+            if (context.Source.Currency.IsNullOrEmpty())
+            {
+                return order.Currency;
+            }
+
+            return order.AllCurrencies?.FirstOrDefault(x => x.Code.EqualsIgnoreCase(context.Source.Currency));
+        }
+
         public static Currency GetConfiguratonItemCurrency(this IResolveFieldContext<ConfigurationItem> context)
         {
             var order = context.GetOrder();
             var lineItemId = context.Source.LineItemId;
-            var lineItem = order?.Order.Items.FirstOrDefault(x => x.Id == lineItemId);
-            return context.GetCurrencyByCode(lineItem?.Currency);
+            var lineItem = order?.Order?.Items?.FirstOrDefault(x => x.Id == lineItemId);
+            if (lineItem == null)
+            {
+                return null;
+            }
+
+            if (lineItem.Currency.IsNullOrEmpty())
+            {
+                return order.Currency;
+            }
+
+            return order.AllCurrencies?.FirstOrDefault(x => x.Code.EqualsIgnoreCase(lineItem.Currency));
         }
     }
 }

--- a/src/VirtoCommerce.XOrder.Core/Models/OrderTotalAggregate.cs
+++ b/src/VirtoCommerce.XOrder.Core/Models/OrderTotalAggregate.cs
@@ -1,0 +1,14 @@
+using VirtoCommerce.CoreModule.Core.Currency;
+using VirtoCommerce.OrdersModule.Core.Model;
+
+namespace VirtoCommerce.XOrder.Core.Models
+{
+    public class OrderTotalAggregate
+    {
+        public bool IsDefaultTotalCurrency { get; set; }
+
+        public Currency Currency { get; set; }
+
+        public OrderTotal OrderTotal { get; set; }
+    }
+}

--- a/src/VirtoCommerce.XOrder.Core/Schemas/CustomerOrderType.cs
+++ b/src/VirtoCommerce.XOrder.Core/Schemas/CustomerOrderType.cs
@@ -176,6 +176,10 @@ namespace VirtoCommerce.XOrder.Core.Schemas
 
                     return result.Results;
                 });
+
+            ExtendableField<ListGraphType<OrderTotalType>>("orderTotals",
+                "Order totals",
+                resolve: context => context.Source.OrderTotals);
         }
     }
 }

--- a/src/VirtoCommerce.XOrder.Core/Schemas/OrderConfigurationItemType.cs
+++ b/src/VirtoCommerce.XOrder.Core/Schemas/OrderConfigurationItemType.cs
@@ -30,15 +30,15 @@ public class OrderConfigurationItemType : ExtendableGraphType<ConfigurationItem>
 
         Field<NonNullGraphType<MoneyType>>(nameof(ConfigurationItem.Price))
             .Description("List price")
-            .Resolve(context => context.Source.Price.ToMoney(context.GetOrderCurrency()));
+            .Resolve(context => context.Source.Price.ToMoney(context.GetConfiguratonItemCurrency()));
 
         Field<NonNullGraphType<MoneyType>>(nameof(ConfigurationItem.SalePrice))
             .Description("Sale price")
-            .Resolve(context => context.Source.SalePrice.ToMoney(context.GetOrderCurrency()));
+            .Resolve(context => context.Source.SalePrice.ToMoney(context.GetConfiguratonItemCurrency()));
 
         Field<NonNullGraphType<MoneyType>>(nameof(ConfigurationItem.ExtendedPrice))
             .Description("Extended price")
-            .Resolve(context => context.Source.ExtendedPrice.ToMoney(context.GetOrderCurrency()));
+            .Resolve(context => context.Source.ExtendedPrice.ToMoney(context.GetConfiguratonItemCurrency()));
 
         ExtendableField<ListGraphType<OrderConfigurationItemFileType>>(nameof(ConfigurationItem.Files),
             resolve: context => context.Source.Files,

--- a/src/VirtoCommerce.XOrder.Core/Schemas/OrderLineItemType.cs
+++ b/src/VirtoCommerce.XOrder.Core/Schemas/OrderLineItemType.cs
@@ -15,7 +15,6 @@ using VirtoCommerce.Xapi.Core.Services;
 using VirtoCommerce.XCatalog.Core.Models;
 using VirtoCommerce.XCatalog.Core.Schemas;
 using VirtoCommerce.XOrder.Core.Extensions;
-using Money = VirtoCommerce.CoreModule.Core.Currency.Money;
 using OrderSettings = VirtoCommerce.OrdersModule.Core.ModuleConstants.Settings.General;
 
 namespace VirtoCommerce.XOrder.Core.Schemas
@@ -60,13 +59,13 @@ namespace VirtoCommerce.XOrder.Core.Schemas
             Field(x => x.Sku, nullable: false);
             Field(x => x.PriceId, nullable: true);
             Field<NonNullGraphType<MoneyType>>(nameof(LineItem.Price).ToCamelCase())
-                .Resolve(context => new Money(context.Source.Price, context.GetOrderCurrency()));
+                .Resolve(context => context.Source.Price.ToMoney(context.GetLineItemCurrency()));
             Field<NonNullGraphType<MoneyType>>(nameof(LineItem.PriceWithTax).ToCamelCase())
-                .Resolve(context => new Money(context.Source.PriceWithTax, context.GetOrderCurrency()));
+                .Resolve(context => context.Source.PriceWithTax.ToMoney(context.GetLineItemCurrency()));
             Field<NonNullGraphType<MoneyType>>(nameof(LineItem.ListTotal).ToCamelCase())
-                .Resolve(context => context.Source.ListTotal.ToMoney(context.GetOrderCurrency()));
+                .Resolve(context => context.Source.ListTotal.ToMoney(context.GetLineItemCurrency()));
             Field<NonNullGraphType<MoneyType>>(nameof(LineItem.ListTotalWithTax).ToCamelCase())
-                .Resolve(context => context.Source.ListTotalWithTax.ToMoney(context.GetOrderCurrency()));
+                .Resolve(context => context.Source.ListTotalWithTax.ToMoney(context.GetLineItemCurrency()));
             Field(x => x.TaxType, nullable: true);
             Field(x => x.TaxPercentRate, nullable: false);
             Field(x => x.ReserveQuantity, nullable: false);
@@ -74,28 +73,28 @@ namespace VirtoCommerce.XOrder.Core.Schemas
             Field(x => x.ProductId, nullable: false);
 
             Field<NonNullGraphType<CurrencyType>>(nameof(LineItem.Currency).ToCamelCase())
-                .Resolve(context => context.GetOrderCurrency());
+                .Resolve(context => context.GetLineItemCurrency());
             Field<NonNullGraphType<MoneyType>>(nameof(LineItem.DiscountAmount).ToCamelCase())
-                .Resolve(context => new Money(context.Source.DiscountAmount, context.GetOrderCurrency()));
+                .Resolve(context => context.Source.DiscountAmount.ToMoney(context.GetLineItemCurrency()));
             Field<NonNullGraphType<MoneyType>>(nameof(LineItem.DiscountAmountWithTax).ToCamelCase())
-                .Resolve(context => new Money(context.Source.DiscountAmountWithTax, context.GetOrderCurrency()));
+                .Resolve(context => context.Source.DiscountAmountWithTax.ToMoney(context.GetLineItemCurrency()));
             Field<NonNullGraphType<MoneyType>>(nameof(LineItem.DiscountTotal).ToCamelCase())
-                .Resolve(context => new Money(context.Source.DiscountTotal, context.GetOrderCurrency()));
+                .Resolve(context => context.Source.DiscountTotal.ToMoney(context.GetLineItemCurrency()));
             Field<NonNullGraphType<MoneyType>>(nameof(LineItem.DiscountTotalWithTax).ToCamelCase())
-                .Resolve(context => new Money(context.Source.DiscountTotalWithTax, context.GetOrderCurrency()));
+                .Resolve(context => context.Source.DiscountTotalWithTax.ToMoney(context.GetLineItemCurrency()));
             Field<NonNullGraphType<MoneyType>>(nameof(LineItem.ExtendedPrice).ToCamelCase())
-                .Resolve(context => new Money(context.Source.ExtendedPrice, context.GetOrderCurrency()));
+                .Resolve(context => context.Source.ExtendedPrice.ToMoney(context.GetLineItemCurrency()));
             Field<NonNullGraphType<MoneyType>>(nameof(LineItem.ExtendedPriceWithTax).ToCamelCase())
-                .Resolve(context => new Money(context.Source.ExtendedPriceWithTax, context.GetOrderCurrency()));
+                .Resolve(context => context.Source.ExtendedPriceWithTax.ToMoney(context.GetLineItemCurrency()));
             Field<NonNullGraphType<BooleanGraphType>>("showPlacedPrice")
                 .Description("Indicates whether the PlacedPrice should be visible to the customer")
                 .Resolve(context => context.Source.IsDiscountAmountRounded);
             Field<NonNullGraphType<MoneyType>>(nameof(LineItem.PlacedPrice).ToCamelCase())
-                .Resolve(context => new Money(context.Source.PlacedPrice, context.GetOrderCurrency()));
+                .Resolve(context => context.Source.PlacedPrice.ToMoney(context.GetLineItemCurrency()));
             Field<NonNullGraphType<MoneyType>>(nameof(LineItem.PlacedPriceWithTax).ToCamelCase())
-                .Resolve(context => new Money(context.Source.PlacedPriceWithTax, context.GetOrderCurrency()));
+                .Resolve(context => context.Source.PlacedPriceWithTax.ToMoney(context.GetLineItemCurrency()));
             Field<NonNullGraphType<MoneyType>>(nameof(LineItem.TaxTotal).ToCamelCase())
-                .Resolve(context => new Money(context.Source.TaxTotal, context.GetOrderCurrency()));
+                .Resolve(context => context.Source.TaxTotal.ToMoney(context.GetLineItemCurrency()));
             Field<NonNullGraphType<ListGraphType<NonNullGraphType<OrderTaxDetailType>>>>(nameof(LineItem.TaxDetails))
                 .Resolve(x => x.Source.TaxDetails);
             Field<NonNullGraphType<ListGraphType<NonNullGraphType<OrderDiscountType>>>>(nameof(LineItem.Discounts))

--- a/src/VirtoCommerce.XOrder.Core/Schemas/OrderLineItemType.cs
+++ b/src/VirtoCommerce.XOrder.Core/Schemas/OrderLineItemType.cs
@@ -73,7 +73,7 @@ namespace VirtoCommerce.XOrder.Core.Schemas
             Field(x => x.ProductId, nullable: false);
 
             Field<NonNullGraphType<CurrencyType>>(nameof(LineItem.Currency).ToCamelCase())
-                .Resolve(context => context.GetCurrencyByCode(context.Source.Currency));
+                .Resolve(context => context.GetOrderItemCurrency());
             Field<NonNullGraphType<MoneyType>>(nameof(LineItem.DiscountAmount).ToCamelCase())
                 .Resolve(context => context.Source.DiscountAmount.ToMoney(context.GetOrderItemCurrency()));
             Field<NonNullGraphType<MoneyType>>(nameof(LineItem.DiscountAmountWithTax).ToCamelCase())

--- a/src/VirtoCommerce.XOrder.Core/Schemas/OrderLineItemType.cs
+++ b/src/VirtoCommerce.XOrder.Core/Schemas/OrderLineItemType.cs
@@ -59,13 +59,13 @@ namespace VirtoCommerce.XOrder.Core.Schemas
             Field(x => x.Sku, nullable: false);
             Field(x => x.PriceId, nullable: true);
             Field<NonNullGraphType<MoneyType>>(nameof(LineItem.Price).ToCamelCase())
-                .Resolve(context => context.Source.Price.ToMoney(context.GetLineItemCurrency()));
+                .Resolve(context => context.Source.Price.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
             Field<NonNullGraphType<MoneyType>>(nameof(LineItem.PriceWithTax).ToCamelCase())
-                .Resolve(context => context.Source.PriceWithTax.ToMoney(context.GetLineItemCurrency()));
+                .Resolve(context => context.Source.PriceWithTax.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
             Field<NonNullGraphType<MoneyType>>(nameof(LineItem.ListTotal).ToCamelCase())
-                .Resolve(context => context.Source.ListTotal.ToMoney(context.GetLineItemCurrency()));
+                .Resolve(context => context.Source.ListTotal.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
             Field<NonNullGraphType<MoneyType>>(nameof(LineItem.ListTotalWithTax).ToCamelCase())
-                .Resolve(context => context.Source.ListTotalWithTax.ToMoney(context.GetLineItemCurrency()));
+                .Resolve(context => context.Source.ListTotalWithTax.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
             Field(x => x.TaxType, nullable: true);
             Field(x => x.TaxPercentRate, nullable: false);
             Field(x => x.ReserveQuantity, nullable: false);
@@ -73,28 +73,28 @@ namespace VirtoCommerce.XOrder.Core.Schemas
             Field(x => x.ProductId, nullable: false);
 
             Field<NonNullGraphType<CurrencyType>>(nameof(LineItem.Currency).ToCamelCase())
-                .Resolve(context => context.GetLineItemCurrency());
+                .Resolve(context => context.GetCurrencyByCode(context.Source.Currency));
             Field<NonNullGraphType<MoneyType>>(nameof(LineItem.DiscountAmount).ToCamelCase())
-                .Resolve(context => context.Source.DiscountAmount.ToMoney(context.GetLineItemCurrency()));
+                .Resolve(context => context.Source.DiscountAmount.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
             Field<NonNullGraphType<MoneyType>>(nameof(LineItem.DiscountAmountWithTax).ToCamelCase())
-                .Resolve(context => context.Source.DiscountAmountWithTax.ToMoney(context.GetLineItemCurrency()));
+                .Resolve(context => context.Source.DiscountAmountWithTax.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
             Field<NonNullGraphType<MoneyType>>(nameof(LineItem.DiscountTotal).ToCamelCase())
-                .Resolve(context => context.Source.DiscountTotal.ToMoney(context.GetLineItemCurrency()));
+                .Resolve(context => context.Source.DiscountTotal.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
             Field<NonNullGraphType<MoneyType>>(nameof(LineItem.DiscountTotalWithTax).ToCamelCase())
-                .Resolve(context => context.Source.DiscountTotalWithTax.ToMoney(context.GetLineItemCurrency()));
+                .Resolve(context => context.Source.DiscountTotalWithTax.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
             Field<NonNullGraphType<MoneyType>>(nameof(LineItem.ExtendedPrice).ToCamelCase())
-                .Resolve(context => context.Source.ExtendedPrice.ToMoney(context.GetLineItemCurrency()));
+                .Resolve(context => context.Source.ExtendedPrice.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
             Field<NonNullGraphType<MoneyType>>(nameof(LineItem.ExtendedPriceWithTax).ToCamelCase())
-                .Resolve(context => context.Source.ExtendedPriceWithTax.ToMoney(context.GetLineItemCurrency()));
+                .Resolve(context => context.Source.ExtendedPriceWithTax.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
             Field<NonNullGraphType<BooleanGraphType>>("showPlacedPrice")
                 .Description("Indicates whether the PlacedPrice should be visible to the customer")
                 .Resolve(context => context.Source.IsDiscountAmountRounded);
             Field<NonNullGraphType<MoneyType>>(nameof(LineItem.PlacedPrice).ToCamelCase())
-                .Resolve(context => context.Source.PlacedPrice.ToMoney(context.GetLineItemCurrency()));
+                .Resolve(context => context.Source.PlacedPrice.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
             Field<NonNullGraphType<MoneyType>>(nameof(LineItem.PlacedPriceWithTax).ToCamelCase())
-                .Resolve(context => context.Source.PlacedPriceWithTax.ToMoney(context.GetLineItemCurrency()));
+                .Resolve(context => context.Source.PlacedPriceWithTax.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
             Field<NonNullGraphType<MoneyType>>(nameof(LineItem.TaxTotal).ToCamelCase())
-                .Resolve(context => context.Source.TaxTotal.ToMoney(context.GetLineItemCurrency()));
+                .Resolve(context => context.Source.TaxTotal.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
             Field<NonNullGraphType<ListGraphType<NonNullGraphType<OrderTaxDetailType>>>>(nameof(LineItem.TaxDetails))
                 .Resolve(x => x.Source.TaxDetails);
             Field<NonNullGraphType<ListGraphType<NonNullGraphType<OrderDiscountType>>>>(nameof(LineItem.Discounts))

--- a/src/VirtoCommerce.XOrder.Core/Schemas/OrderLineItemType.cs
+++ b/src/VirtoCommerce.XOrder.Core/Schemas/OrderLineItemType.cs
@@ -59,13 +59,13 @@ namespace VirtoCommerce.XOrder.Core.Schemas
             Field(x => x.Sku, nullable: false);
             Field(x => x.PriceId, nullable: true);
             Field<NonNullGraphType<MoneyType>>(nameof(LineItem.Price).ToCamelCase())
-                .Resolve(context => context.Source.Price.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
+                .Resolve(context => context.Source.Price.ToMoney(context.GetOrderItemCurrency()));
             Field<NonNullGraphType<MoneyType>>(nameof(LineItem.PriceWithTax).ToCamelCase())
-                .Resolve(context => context.Source.PriceWithTax.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
+                .Resolve(context => context.Source.PriceWithTax.ToMoney(context.GetOrderItemCurrency()));
             Field<NonNullGraphType<MoneyType>>(nameof(LineItem.ListTotal).ToCamelCase())
-                .Resolve(context => context.Source.ListTotal.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
+                .Resolve(context => context.Source.ListTotal.ToMoney(context.GetOrderItemCurrency()));
             Field<NonNullGraphType<MoneyType>>(nameof(LineItem.ListTotalWithTax).ToCamelCase())
-                .Resolve(context => context.Source.ListTotalWithTax.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
+                .Resolve(context => context.Source.ListTotalWithTax.ToMoney(context.GetOrderItemCurrency()));
             Field(x => x.TaxType, nullable: true);
             Field(x => x.TaxPercentRate, nullable: false);
             Field(x => x.ReserveQuantity, nullable: false);
@@ -75,26 +75,26 @@ namespace VirtoCommerce.XOrder.Core.Schemas
             Field<NonNullGraphType<CurrencyType>>(nameof(LineItem.Currency).ToCamelCase())
                 .Resolve(context => context.GetCurrencyByCode(context.Source.Currency));
             Field<NonNullGraphType<MoneyType>>(nameof(LineItem.DiscountAmount).ToCamelCase())
-                .Resolve(context => context.Source.DiscountAmount.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
+                .Resolve(context => context.Source.DiscountAmount.ToMoney(context.GetOrderItemCurrency()));
             Field<NonNullGraphType<MoneyType>>(nameof(LineItem.DiscountAmountWithTax).ToCamelCase())
-                .Resolve(context => context.Source.DiscountAmountWithTax.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
+                .Resolve(context => context.Source.DiscountAmountWithTax.ToMoney(context.GetOrderItemCurrency()));
             Field<NonNullGraphType<MoneyType>>(nameof(LineItem.DiscountTotal).ToCamelCase())
-                .Resolve(context => context.Source.DiscountTotal.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
+                .Resolve(context => context.Source.DiscountTotal.ToMoney(context.GetOrderItemCurrency()));
             Field<NonNullGraphType<MoneyType>>(nameof(LineItem.DiscountTotalWithTax).ToCamelCase())
-                .Resolve(context => context.Source.DiscountTotalWithTax.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
+                .Resolve(context => context.Source.DiscountTotalWithTax.ToMoney(context.GetOrderItemCurrency()));
             Field<NonNullGraphType<MoneyType>>(nameof(LineItem.ExtendedPrice).ToCamelCase())
-                .Resolve(context => context.Source.ExtendedPrice.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
+                .Resolve(context => context.Source.ExtendedPrice.ToMoney(context.GetOrderItemCurrency()));
             Field<NonNullGraphType<MoneyType>>(nameof(LineItem.ExtendedPriceWithTax).ToCamelCase())
-                .Resolve(context => context.Source.ExtendedPriceWithTax.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
+                .Resolve(context => context.Source.ExtendedPriceWithTax.ToMoney(context.GetOrderItemCurrency()));
             Field<NonNullGraphType<BooleanGraphType>>("showPlacedPrice")
                 .Description("Indicates whether the PlacedPrice should be visible to the customer")
                 .Resolve(context => context.Source.IsDiscountAmountRounded);
             Field<NonNullGraphType<MoneyType>>(nameof(LineItem.PlacedPrice).ToCamelCase())
-                .Resolve(context => context.Source.PlacedPrice.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
+                .Resolve(context => context.Source.PlacedPrice.ToMoney(context.GetOrderItemCurrency()));
             Field<NonNullGraphType<MoneyType>>(nameof(LineItem.PlacedPriceWithTax).ToCamelCase())
-                .Resolve(context => context.Source.PlacedPriceWithTax.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
+                .Resolve(context => context.Source.PlacedPriceWithTax.ToMoney(context.GetOrderItemCurrency()));
             Field<NonNullGraphType<MoneyType>>(nameof(LineItem.TaxTotal).ToCamelCase())
-                .Resolve(context => context.Source.TaxTotal.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
+                .Resolve(context => context.Source.TaxTotal.ToMoney(context.GetOrderItemCurrency()));
             Field<NonNullGraphType<ListGraphType<NonNullGraphType<OrderTaxDetailType>>>>(nameof(LineItem.TaxDetails))
                 .Resolve(x => x.Source.TaxDetails);
             Field<NonNullGraphType<ListGraphType<NonNullGraphType<OrderDiscountType>>>>(nameof(LineItem.Discounts))

--- a/src/VirtoCommerce.XOrder.Core/Schemas/OrderTotalType.cs
+++ b/src/VirtoCommerce.XOrder.Core/Schemas/OrderTotalType.cs
@@ -1,0 +1,31 @@
+using GraphQL.Types;
+using VirtoCommerce.Xapi.Core.Extensions;
+using VirtoCommerce.Xapi.Core.Schemas;
+using VirtoCommerce.XOrder.Core.Models;
+
+namespace VirtoCommerce.XOrder.Core.Schemas
+{
+    public class OrderTotalType : ExtendableGraphType<OrderTotalAggregate>
+    {
+        public OrderTotalType()
+        {
+            Field(x => x.IsDefaultTotalCurrency, nullable: false).Description("Is current total in default total currency");
+
+            Field<NonNullGraphType<MoneyType>>("total")
+                .Description("Cart total")
+                .Resolve(context => context.Source.OrderTotal.Total.ToMoney(context.Source.Currency));
+
+            Field<NonNullGraphType<MoneyType>>("subTotal")
+                .Description("Cart subtotal")
+                .Resolve(context => context.Source.OrderTotal.SubTotal.ToMoney(context.Source.Currency));
+
+            Field<NonNullGraphType<MoneyType>>("taxTotal")
+                .Description("Total tax")
+                .Resolve(context => context.Source.OrderTotal.TaxTotal.ToMoney(context.Source.Currency));
+
+            Field<NonNullGraphType<MoneyType>>("discountTotal")
+                .Description("Total discount")
+                .Resolve(context => context.Source.OrderTotal.DiscountTotal.ToMoney(context.Source.Currency));
+        }
+    }
+}

--- a/src/VirtoCommerce.XOrder.Core/VirtoCommerce.XOrder.Core.csproj
+++ b/src/VirtoCommerce.XOrder.Core/VirtoCommerce.XOrder.Core.csproj
@@ -8,7 +8,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.1007.0" />
+    <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.1009.0-alpha.1423-vcst-5104" />
     <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.1002.0" />
     <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1001.0" />
     <PackageReference Include="VirtoCommerce.XCart.Core" Version="3.1001.0" />

--- a/src/VirtoCommerce.XOrder.Data/Services/CustomerOrderAggregateRepository.cs
+++ b/src/VirtoCommerce.XOrder.Data/Services/CustomerOrderAggregateRepository.cs
@@ -82,9 +82,14 @@ namespace VirtoCommerce.XOrder.Data.Services
 
             foreach (var order in orders)
             {
+                var orderCurrencies = currencies
+                    .Select(x => currencies.GetCurrencyForLanguage(x.Code, cultureName ?? order.LanguageCode))
+                    .ToList();
+
                 var aggregateFactory = _customerOrderAggregateFactory();
                 var orderAggregate = aggregateFactory.GrabCustomerOrder(order.CloneTyped(),
                     currencies.GetCurrencyForLanguage(order.Currency, cultureName ?? order.LanguageCode),
+                    orderCurrencies,
                     await GetStore(order.StoreId));
                 orderAggregates.Add(orderAggregate);
             }

--- a/src/VirtoCommerce.XOrder.Web/module.manifest
+++ b/src/VirtoCommerce.XOrder.Web/module.manifest
@@ -7,7 +7,7 @@
   <platformVersion>3.1016.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.FileExperienceApi" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Orders" version="3.1007.0" />
+    <dependency id="VirtoCommerce.Orders" version="3.1009.0-alpha.1423-vcst-5104" />
     <dependency id="VirtoCommerce.Payment" version="3.1002.0" />
     <dependency id="VirtoCommerce.Xapi" version="3.1001.0" />
     <dependency id="VirtoCommerce.XCart" version="3.1001.0" />

--- a/tests/VirtoCommerce.XOrder.Tests/Helpers/CustomerOrderMockHelper.cs
+++ b/tests/VirtoCommerce.XOrder.Tests/Helpers/CustomerOrderMockHelper.cs
@@ -113,7 +113,7 @@ namespace VirtoCommerce.XOrder.Tests.Helpers
                 _dynamicPropertyUpdaterService.Object,
                 _promotionUsageSearchService.Object);
 
-            aggregate.GrabCustomerOrder(customerOrder, currency, null);
+            aggregate.GrabCustomerOrder(customerOrder, currency, null, null);
 
             return aggregate;
         }

--- a/tests/VirtoCommerce.XOrder.Tests/Schemas/ProductSnapshotResolutionTest.cs
+++ b/tests/VirtoCommerce.XOrder.Tests/Schemas/ProductSnapshotResolutionTest.cs
@@ -93,7 +93,7 @@ public class ProductSnapshotResolutionTests
 
         var order = new CustomerOrder { Id = orderId };
         var orderAggregate = new CustomerOrderAggregate(null, null);
-        orderAggregate.GrabCustomerOrder(order, null, null);
+        orderAggregate.GrabCustomerOrder(order, null, null, null);
 
         // SetExpandedObjectGraph puts the aggregate under each entity's Id
         userContext.TryAdd(lineItemId, orderAggregate);


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:
### Artifact URL:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how order and line-item prices are resolved in GraphQL and depends on a pre-release Orders module; incorrect currency mapping could show wrong amounts to customers.
> 
> **Overview**
> Adds **mixed-currency** support to the Order Experience API so line-item and configuration-item money fields use each line’s `Currency` (falling back to the order currency), instead of always using the order’s main currency.
> 
> `CustomerOrderAggregate` now keeps a localized **list of all currencies** and exposes computed **`orderTotals`** (backed by new `OrderTotalAggregate` + `OrderTotalType`) for per-currency totals from the Orders module, including a flag for the default order currency. Order loading passes the full currency list into `GrabCustomerOrder`.
> 
> Bumps **`VirtoCommerce.OrdersModule.Core`** / **`VirtoCommerce.Orders`** to `3.1010.0-alpha.1429-vcst-5104` for the underlying order model changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a67a8c7c61da3ed3d10022558eec903aa94912af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->